### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ class ArticleResource
   attributes :title
 end
 
-class UserResource1
+class UserResource
   include Alba::Resource
 
   attributes :id
@@ -123,7 +123,7 @@ user.articles << article1
 article2 = Article.new(2, 'Super nice', 'Really nice!')
 user.articles << article2
 
-UserResource1.new(user).serialize
+UserResource.new(user).serialize
 # => '{"id":1,"articles":[{"title":"Hello World!"},{"title":"Super nice"}]}'
 ```
 


### PR DESCRIPTION
## Summary
I thought `1` of `class UserResource1` in `README.md` was typo, so I fixed it.