### PR TITLE
Implement user defined error handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ AllCops:
     - 'benchmark/**/*.rb'
   NewCops: enable
   EnabledByDefault: true
+  TargetRubyVersion: 2.5
 
 # Oneline comment is not valid so until it gets valid, we disable it
 Bundler/GemComment:

--- a/lib/alba.rb
+++ b/lib/alba.rb
@@ -10,7 +10,7 @@ module Alba
   class UnsupportedBackend < Error; end
 
   class << self
-    attr_reader :backend, :encoder, :inferring
+    attr_reader :backend, :encoder, :inferring, :_on_error
 
     # Set the backend, which actually serializes object into JSON
     #
@@ -51,6 +51,18 @@ module Alba
     # Disable inference for key and resource name
     def disable_inference!
       @inferring = false
+    end
+
+    # Set error handler
+    #
+    # @param [Symbol] handler
+    # @param [Block]
+    def on_error(handler = nil, &block)
+      raise ArgumentError, 'You cannot specify error handler with both Symbol and block' if handler && block
+      raise ArgumentError, 'You must specify error handler with either Symbol or block' unless handler || block
+
+      p block if block
+      @_on_error = handler || block
     end
 
     private
@@ -98,4 +110,5 @@ module Alba
   end
 
   @encoder = default_encoder
+  @_on_error = :raise
 end

--- a/test/usecases/on_error_test.rb
+++ b/test/usecases/on_error_test.rb
@@ -1,0 +1,99 @@
+require_relative '../test_helper'
+
+class OnErrorTest < MiniTest::Test
+  class User
+    attr_accessor :id, :name, :created_at, :updated_at
+
+    def initialize(id, name, email)
+      @id = id
+      @name = name
+      @email = email
+      @created_at = Time.now
+      @updated_at = Time.now
+    end
+
+    # rubocop:disable Style/RedundantException
+    def email
+      raise RuntimeError, 'Error!'
+    end
+    # rubocop:enable Style/RedundantException
+  end
+
+  class UserResource
+    include Alba::Resource
+
+    key :user
+
+    attributes :id, :name, :email
+  end
+
+  class UserResource1 < UserResource
+    on_error :raise
+  end
+
+  class UserResource2 < UserResource
+    on_error :ignore
+  end
+
+  class UserResource3 < UserResource
+    on_error :nullify
+  end
+
+  class UserResource4 < UserResource
+    on_error do |error, _, key|
+      [key, error.message]
+    end
+  end
+
+  class UserResource5 < UserResource
+    Alba.on_error do |error|
+      ['error', error.message]
+    end
+    on_error :ignore
+  end
+
+  def setup
+    Alba.on_error :raise
+    @user = User.new(1, 'Masafumi OKURA', 'masafumi@example.com')
+  end
+
+  def test_on_error_default
+    assert_raises RuntimeError do
+      UserResource.new(@user).serialize
+    end
+  end
+
+  def test_on_error_raise
+    assert_raises RuntimeError do
+      UserResource1.new(@user).serialize
+    end
+  end
+
+  def test_on_error_ignore
+    assert_equal(
+      '{"user":{"id":1,"name":"Masafumi OKURA"}}',
+      UserResource2.new(@user).serialize
+    )
+  end
+
+  def test_on_error_nullify
+    assert_equal(
+      '{"user":{"id":1,"name":"Masafumi OKURA","email":null}}',
+      UserResource3.new(@user).serialize
+    )
+  end
+
+  def test_on_error_block
+    assert_equal(
+      '{"user":{"id":1,"name":"Masafumi OKURA","email":"Error!"}}',
+      UserResource4.new(@user).serialize
+    )
+  end
+
+  def test_on_error_resource_local_wins_against_global
+    assert_equal(
+      '{"user":{"id":1,"name":"Masafumi OKURA"}}',
+      UserResource5.new(@user).serialize
+    )
+  end
+end


### PR DESCRIPTION
This feature lets users to decide how to deal with errors that occurred when fetching an attribute.
It's especially useful when the serialized object is connected to the database or the network that might causes some errors.