### PR TITLE
Fix changelog URL in gemspec

### DIFF
--- a/alba.gemspec
+++ b/alba.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/okuramasafumi/alba'
-  spec.metadata['changelog_uri'] = 'https://github.com/okuramasafumi/alba/CHANGELOG.md'
+  spec.metadata['changelog_uri'] = 'https://github.com/okuramasafumi/alba/blob/master/CHANGELOG.md'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
Hi, I find the broken URL for the changelog in <https://rubygems.org/gems/alba/versions/1.0.0>:

<img width="149" alt="image" src="https://user-images.githubusercontent.com/473530/113981001-1c209580-9882-11eb-8776-5015ab31265b.png">

This PR just fixes it. Thanks. 😃 