### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Alba
 
-`Alba` is the fastest JSON serializer for Ruby, JRuby an TruffleRuby.
+Alba is the fastest JSON serializer for Ruby, JRuby, and TruffleRuby.
 
 ## Discussions
 


### PR DESCRIPTION
Hi, I find the following typos in the README. (the former may not be a typo, though)

- Remove back-ticks from "Alba" because back-ticks are not used in the following sections.
  E.g. "Alba uses GitHub Discussions..."
- Fix typo for "and".
