### PR TITLE
Add jsonapi-serializer gem to benchmark and clean up the file

### DIFF
--- a/benchmark/local.rb
+++ b/benchmark/local.rb
@@ -17,6 +17,7 @@ gemfile(true) do
   gem "alba", path: '../'
   gem "oj"
   gem "multi_json"
+  gem "jsonapi-serializer"
 end
 
 require "active_record"
@@ -159,6 +160,64 @@ class PostRepresenter < Representable::Decorator
   end
 end
 
+class JsonApiStandardCommentSerializer
+  include JSONAPI::Serializer
+
+  attribute :id
+  attribute :body
+end
+
+class JsonApiStandardPostSerializer
+  include JSONAPI::Serializer
+
+  # set_type :post  # optional
+  attribute :id
+  attribute :body
+  attribute :commenter_names
+
+  attribute :comments do |post|
+    post.comments.map { |comment| JsonApiSameFormatCommentSerializer.new(comment) }
+  end
+end
+
+# code to convert from JSON:API output to "flat" JSON, like the other serializers build
+class JsonApiSameFormatSerializer
+  include JSONAPI::Serializer
+
+  def as_json(*_options)
+    hash = serializable_hash
+
+    if hash[:data].is_a? Hash
+      hash[:data][:attributes]
+
+    elsif hash[:data].is_a? Array
+      hash[:data].pluck(:attributes)
+
+    elsif hash[:data].nil?
+      { }
+
+    else
+      raise "unexpected data type #{hash[:data].class}"
+    end
+  end
+end
+
+class JsonApiSameFormatCommentSerializer < JsonApiSameFormatSerializer
+  attribute :id
+  attribute :body
+end
+
+class JsonApiSameFormatPostSerializer < JsonApiSameFormatSerializer
+  # set_type :post  # optional
+  attribute :id
+  attribute :body
+  attribute :commenter_names
+
+  attribute :comments do |post|
+    post.comments.map { |comment| JsonApiSameFormatCommentSerializer.new(comment) }
+  end
+end
+
 post = Post.create!(body: 'post')
 user1 = User.create!(name: 'John')
 user2 = User.create!(name: 'Jane')
@@ -183,7 +242,8 @@ alba_inline = Proc.new do
     end
   end
 end
-[alba, jbuilder, ams, rails, blueprinter, representable, alba_inline].each {|x| puts x.call }
+
+[alba, jbuilder, rails, ams, blueprinter, representable, alba_inline, jsonapi, jsonapi_same_format].each {|x| puts x.call }
 
 require 'benchmark'
 time = 1000
@@ -195,4 +255,6 @@ Benchmark.bmbm do |x|
   x.report(:blueprinter) { time.times(&blueprinter) }
   x.report(:representable) { time.times(&representable) }
   x.report(:alba_inline) { time.times(&alba_inline) }
+  x.report(:jsonapi) { time.times(&jsonapi) }
+  x.report(:jsonapi_same_format) { time.times(&jsonapi_same_format) }
 end

--- a/benchmark/local.rb
+++ b/benchmark/local.rb
@@ -17,6 +17,7 @@ gemfile(true) do
   gem "alba", path: '../'
   gem "oj"
   gem "multi_json"
+  gem "benchmark-ips"
   gem "jsonapi-serializer"
 end
 
@@ -27,7 +28,7 @@ require "oj"
 Oj.optimize_rails
 
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
-# ActiveRecord::Base.logger = Logger.new(STDOUT)
+# ActiveRecord::Base.logger = Logger.new($stdout)
 
 ActiveRecord::Schema.define do
   create_table :posts, force: true do |t|
@@ -257,4 +258,19 @@ Benchmark.bmbm do |x|
   x.report(:alba_inline) { time.times(&alba_inline) }
   x.report(:jsonapi) { time.times(&jsonapi) }
   x.report(:jsonapi_same_format) { time.times(&jsonapi_same_format) }
+end
+
+require 'benchmark/ips'
+Benchmark.ips do |x|
+  x.report(:alba, &alba)
+  x.report(:jbuilder, &jbuilder)
+  x.report(:ams, &ams)
+  x.report(:rails, &rails)
+  x.report(:blueprinter, &blueprinter)
+  x.report(:representable, &representable)
+  x.report(:alba_inline, &alba_inline)
+  x.report(:jsonapi, &jsonapi)
+  x.report(:jsonapi_same_format, &jsonapi_same_format)
+
+  x.compare!
 end


### PR DESCRIPTION
Hey, I like your simple gem and that it includes a benchmark with various other gems. I was missing the **jsonapi-serializers** (formerly known as _fast_jsonapi_) gem and therefore I've added it.  I've also added `benchmark/ips` and refactored the benchmark file (sorting calls and declarations alphabetically and adding some comments to make it simpler to understand the file).

Ok, now you might wonder: _"but jsonapi-serializers formats the output differently"_ and you would be correct. But as I've done in a few projects before, where some endpoints needed a simple, 'flat' serialization and didn't follow the JSON:API standard, I've overwritten its `as_json` method to get the same output as with the other serializers.

And it is still fast, almost as fast as **alba**.

---

> _I recommend to review this **commit by commit** as this will make it easier to understand the changes._ 
>
> _Looking at the final version of [benchmark/local.rb](https://github.com/okuramasafumi/alba/blob/12640c6afa066c1a753dbd5412ff797853d9fb98/benchmark/local.rb) might also be easier than trying to understand the diff in which I moved multiple blocks and lines up or down to sort them alphabetically._

--- 

**benchmark/ips output:**

```log
Comparison:
            jbuilder:     4676.4 i/s
                alba:     4666.7 i/s - same-ish: difference falls within error
 jsonapi_same_format:     4433.5 i/s - 1.05x  (± 0.00) slower
         blueprinter:     4250.1 i/s - 1.10x  (± 0.00) slower
             jsonapi:     4089.7 i/s - 1.14x  (± 0.00) slower
       representable:     4073.6 i/s - 1.15x  (± 0.00) slower
                 ams:     3651.2 i/s - 1.28x  (± 0.00) slower
         alba_inline:     3330.4 i/s - 1.40x  (± 0.00) slower
               rails:     2641.7 i/s - 1.77x  (± 0.00) slower
```

---

PS: I've got the idea from a tweet of @jgaskins who started to expand the benchmark (but didn't open a PR yet):  
https://github.com/jgaskins/alba/commit/ad78703e844868c549cc5cf445bd7b7d2e3616e4
