### PR TITLE
Add primalize benchmark

### DIFF
--- a/benchmark/local.rb
+++ b/benchmark/local.rb
@@ -112,28 +112,6 @@ class AMSPostSerializer < ActiveModel::Serializer
   end
 end
 
-# --- Primalize serializers ---
-#
-class PrimalizeCommentResource < Primalize::Single
-  attributes id: integer, body: string
-end
-
-class PrimalizePostResource < Primalize::Single
-  alias post object
-
-  attributes(
-    id: integer,
-    body: string,
-    comments: array(primalize(PrimalizeCommentResource)),
-    commenter_names: array(string),
-  )
-
-  def commenter_names
-    post.commenters.pluck(:name)
-  end
-end
-
-
 # --- Blueprint serializers ---
 
 require "blueprinter"
@@ -233,6 +211,27 @@ class JsonApiSameFormatPostSerializer < JsonApiSameFormatSerializer
 
   attribute :comments do |post|
     post.comments.map { |comment| JsonApiSameFormatCommentSerializer.new(comment) }
+  end
+end
+
+# --- Primalize serializers ---
+#
+class PrimalizeCommentResource < Primalize::Single
+  attributes id: integer, body: string
+end
+
+class PrimalizePostResource < Primalize::Single
+  alias post object
+
+  attributes(
+    id: integer,
+    body: string,
+    comments: array(primalize(PrimalizeCommentResource)),
+    commenter_names: array(string),
+  )
+
+  def commenter_names
+    post.commenters.pluck(:name)
   end
 end
 


### PR DESCRIPTION
@mediafinger asked if I could push my branch where I added Primalize to the benchmark. Nice work making it so easy to extend!

Primalize is a type-checking serializer library, written while I was at a previous company to validate their API output. I wrote a [blog post](https://dev.to/jgaskins/fast-type-checked-serializers-for-ruby-web-apis-2o19) about the type-checking part of it, but we also discovered at the time that it was pretty fast, so I figured when I saw Alba in Ruby Weekly and there was a benchmark already written that I'd check it against Primalize. 🙂 