### PR TITLE
[Fix] Fix multiple-word key inference

### DIFF
--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -58,13 +58,11 @@ module Alba
 
       # @return [String]
       def _key
-        if @_key == true && Alba.inferring
-          demodulized = ActiveSupport::Inflector.demodulize(self.class.name)
-          meth = collection? ? :tableize : :singularize
-          ActiveSupport::Inflector.public_send(meth, demodulized.delete_suffix('Resource').downcase)
-        else
-          @_key.to_s
-        end
+        return @_key.to_s unless @_key == true && Alba.inferring
+
+        resource_name = self.class.name.demodulize.delete_suffix('Resource').underscore
+
+        transform_key(collection? ? resource_name.pluralize : resource_name)
       end
 
       def converter

--- a/test/usecases/key_transform_test.rb
+++ b/test/usecases/key_transform_test.rb
@@ -11,6 +11,14 @@ class KeyTransformTest < Minitest::Test
     end
   end
 
+  class BankAccount
+    attr_reader :account_number
+
+    def initialize(account_number)
+      @account_number = account_number
+    end
+  end
+
   class UserResource
     include Alba::Resource
 
@@ -33,8 +41,24 @@ class KeyTransformTest < Minitest::Test
     transform_keys :unknown
   end
 
+  class BankAccountResource
+    include Alba::Resource
+
+    key!
+
+    attributes :account_number
+    transform_keys :dash
+  end
+
   def setup
+    Alba.enable_inference!
+
     @user = User.new(1, 'Masafumi', 'Okura')
+    @bank_account = BankAccount.new(123456789)
+  end
+
+  def teardown
+    Alba.disable_inference!
   end
 
   def test_transform_key_to_camel
@@ -55,6 +79,13 @@ class KeyTransformTest < Minitest::Test
     assert_equal(
       '{"id":1,"first-name":"Masafumi","last-name":"Okura"}',
       UserResourceDash.new(@user).serialize
+    )
+  end
+
+  def test_transform_key_to_dash_with_key_inference
+    assert_equal(
+      '{"bank-account":{"account-number":123456789}}',
+      BankAccountResource.new(@bank_account).serialize
     )
   end
 

--- a/test/usecases/with_inference_test.rb
+++ b/test/usecases/with_inference_test.rb
@@ -20,6 +20,14 @@ class WithInferenceTest < Minitest::Test
     end
   end
 
+  class BankAccount
+    attr_accessor :account_number
+
+    def initialize(account_number)
+      @account_number = account_number
+    end
+  end
+
   class ArticleResource
     include Alba::Resource
 
@@ -36,6 +44,14 @@ class WithInferenceTest < Minitest::Test
     many :articles, resource: ArticleResource
   end
 
+  class BankAccountResource
+    include Alba::Resource
+
+    key!
+
+    attributes :account_number
+  end
+
   class UserInferringResource
     Alba.enable_inference! # Need this here instead of initializer
     include Alba::Resource
@@ -49,6 +65,7 @@ class WithInferenceTest < Minitest::Test
     Alba.enable_inference!
     @user = User.new(1)
     @user.articles << Article.new(1, 'The title')
+    @bank_account = BankAccount.new(123456789)
   end
 
   def teardown
@@ -66,6 +83,21 @@ class WithInferenceTest < Minitest::Test
     assert_equal(
       '{"user":{"id":1,"articles":[{"title":"The title"}]}}',
       UserResource.new(@user).serialize
+    )
+  end
+
+  def test_it_infers_key_with_key_bang_when_object_name_has_multiple_words
+    assert_equal(
+      '{"bank_account":{"account_number":123456789}}',
+      BankAccountResource.new(@bank_account).serialize
+    )
+  end
+
+  def test_it_infers_key_with_key_bang_when_object_is_collection_and_object_name_has_multiple_words
+    bank_accounts = [@bank_account]
+    assert_equal(
+      '{"bank_accounts":[{"account_number":123456789}]}',
+      BankAccountResource.new(bank_accounts).serialize
     )
   end
 


### PR DESCRIPTION
### Issue

At the moment, when serializing an object with a multiple-word name, the inferred key becomes a single word. For example: `BankAccount` => `bankaccount`.

### How to reproduce

```ruby
require 'alba'

Alba.enable_inference!

class BankAcccount
  attr_accessor :account_number

  def initialize(account_number:)
    @account_number = account_number
  end
end

class BankAccountResource
  include Alba::Resource

  key!

  attributes :account_number
end

bank_account = BankAcccount.new(account_number: 123456789)

puts BankAccountResource.new(bank_account).serialize
puts BankAccountResource.new([bank_account]).serialize
```

Output:

```ruby
{"bankaccount":{"account_number":123456789}}
{"bankaccounts":[{"account_number":123456789}]}
```

### Proposal

This PR replaces `String#downcase` by `ActiveSupport::Inflector.underscore` in `Alba::Resource::_key` method. It also pluralizes the resource name if the object to serialize is a collection. For the previous piece of code, the output would be:

```
{"bank_account":{"account_number":123456789}}
{"bank_accounts":[{"account_number":123456789}]}
```

In case `transform_keys` option is set, the transformation will also apply to the inferred resource key:

```ruby
class BankAccountResource
  include Alba::Resource

  key!

  attributes :account_number
  transform_keys :dash
end
```

Output:

```
{"bank-account":{"account-number":123456789}}
{"bank-accounts":[{"account-number":123456789}]}
```