### PR TITLE
[Feat] Add `Alba.enable_root_key_transformation!`

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ RestrictedFooResouce.new(foo).serialize
 end
 ```
 
-### Attribute key transformation
+### Key transformation
 
 ** Note: You need to install `active_support` gem to use `transform_keys` DSL.
 
@@ -277,6 +277,39 @@ user = User.new(1, 'Masafumi', 'Okura')
 UserResourceCamel.new(user).serialize
 # => '{"id":1,"firstName":"Masafumi","lastName":"Okura"}'
 ```
+
+You can also transform root key when:
+
+* `Alba.enable_inference!` is called
+* `key!` is called in Resource class
+* `root` option of `transform_keys` is set to true or `Alba.enable_root_key_transformation!` is called.
+
+```ruby
+Alba.enable_inference!
+
+class BankAccount
+  attr_reader :account_number
+
+  def initialize(account_number)
+    @account_number = account_number
+  end
+end
+
+class BankAccountResource
+  include Alba::Resource
+
+  key!
+
+  attributes :account_number
+  transform_keys :dash, root: true
+end
+
+bank_account = BankAccount.new(123_456_789)
+BankAccountResource.new(bank_account).serialize
+# => '{"bank-account":{"account-number":123456789}}'
+```
+
+This behavior to transform root key will become default at version 2.
 
 Supported transformation types are :camel, :lower_camel and :dash.
 

--- a/lib/alba.rb
+++ b/lib/alba.rb
@@ -10,7 +10,7 @@ module Alba
   class UnsupportedBackend < Error; end
 
   class << self
-    attr_reader :backend, :encoder, :inferring, :_on_error
+    attr_reader :backend, :encoder, :inferring, :_on_error, :transforming_root_key
 
     # Set the backend, which actually serializes object into JSON
     #
@@ -66,6 +66,16 @@ module Alba
       @_on_error = handler || block
     end
 
+    # Enable root key transformation
+    def enable_root_key_transformation!
+      @transforming_root_key = true
+    end
+
+    # Disable root key transformation
+    def disable_root_key_transformation!
+      @transforming_root_key = false
+    end
+
     private
 
     def set_encoder
@@ -109,4 +119,5 @@ module Alba
 
   @encoder = default_encoder
   @_on_error = :raise
+  @transforming_root_key = false # TODO: This will be true since 2.0
 end

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -6,7 +6,7 @@ module Alba
   module Resource
     # @!parse include InstanceMethods
     # @!parse extend ClassMethods
-    DSLS = {_attributes: {}, _key: nil, _transform_keys: nil, _on_error: nil}.freeze
+    DSLS = {_attributes: {}, _key: nil, _transform_keys: nil, _transforming_root_key: false, _on_error: nil}.freeze
     private_constant :DSLS
 
     # @private
@@ -61,8 +61,9 @@ module Alba
         return @_key.to_s unless @_key == true && Alba.inferring
 
         resource_name = self.class.name.demodulize.delete_suffix('Resource').underscore
-
-        transform_key(collection? ? resource_name.pluralize : resource_name)
+        key = collection? ? resource_name.pluralize : resource_name
+        transforming_root_key = @_transforming_root_key.nil? ? Alba.transforming_root_key : @_transforming_root_key
+        transforming_root_key ? transform_key(key) : key
       end
 
       def converter
@@ -252,8 +253,10 @@ module Alba
       # Transform keys as specified type
       #
       # @param type [String, Symbol]
-      def transform_keys(type)
+      # @param root [Boolean] decides if root key also should be transformed
+      def transform_keys(type, root: nil)
         @_transform_keys = type.to_sym
+        @_transforming_root_key = root
       end
 
       # Set error handler


### PR DESCRIPTION
And `root` option to `transform_keys` method.

This feature is an improvement over the previous commit,
6c18e731310183dc5ca6f626431987b4cdf685f8
It transforms root key, which is a great idea but introduces
backward incompatibility.
This commit adds the flag to control this transformation behavior,
which is default to the old behavior (not transforming root key).
cc: @alfonsojimenez 