### PR TITLE
[Perf] Improve performance for `many`

### DIFF
--- a/lib/alba/many.rb
+++ b/lib/alba/many.rb
@@ -15,7 +15,7 @@ module Alba
       return if @object.nil?
 
       @resource = constantize(@resource)
-      @object.map { |o| @resource.new(o, params: params, within: within).to_hash }
+      @resource.new(@object, params: params, within: within).to_hash
     end
   end
 end


### PR DESCRIPTION
Running [benchmark](https://github.com/okuramasafumi/alba/blob/main/benchmark/collection.rb) shows a surprising result.

Before:

```
# benchmark-ips
alba:       20.9 i/s

# benchmark-memory
                alba     3.720M memsize (    47.240k retained)
                        64.620k objects (   601.000  retained)
                        50.000  strings (     1.000  retained)

```

After:

```
# benchmark-ips
alba:       27.4 i/s

# benchmark-memory
                alba     2.291M memsize (    47.240k retained)
                        39.920k objects (   601.000  retained)
                        50.000  strings (     1.000  retained)

```

Now it's 30% more performant and consumes 40% less memory!