### PR TITLE
Improve key

### DIFF
--- a/lib/alba.rb
+++ b/lib/alba.rb
@@ -32,15 +32,17 @@ module Alba
     # Serialize the object with inline definitions
     #
     # @param object [Object] the object to be serialized
-    # @param key [Symbol]
+    # @param key [Symbol, nil, true] DEPRECATED, use root_key instead
+    # @param root_key [Symbol, nil, true]
     # @param block [Block] resource block
     # @return [String] serialized JSON string
     # @raise [ArgumentError] if block is absent or `with` argument's type is wrong
-    def serialize(object, key: nil, &block)
+    def serialize(object, key: nil, root_key: nil, &block)
+      warn '`key` option to `serialize` method is deprecated, use `root_key` instead.' if key
       klass = block ? resource_class(&block) : infer_resource_class(object.class.name)
 
       resource = klass.new(object)
-      resource.serialize(key: key)
+      resource.serialize(root_key: root_key || key)
     end
 
     # Enable inference for key and resource name

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -294,6 +294,7 @@ module Alba
       def key!
         warn '[DEPRECATION] `key!` is deprecated, use `root_key!` instead.'
         @_key = true
+        @_key_for_collection = true
       end
 
       # Set root key to true

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -43,10 +43,12 @@ module Alba
 
       # Serialize object into JSON string
       #
-      # @param key [Symbol, nil, true]
+      # @param key [Symbol, nil, true] DEPRECATED, use root_key instead
+      # @param root_key [Symbol, nil, true]
       # @return [String] serialized JSON string
-      def serialize(key: nil)
-        key = key.nil? ? fetch_key : key
+      def serialize(key: nil, root_key: nil)
+        warn '`key` option to `serialize` method is deprecated, use `root_key` instead.' if key
+        key = key.nil? && root_key.nil? ? fetch_key : root_key || key
         hash = key && key != '' ? {key.to_s => serializable_hash} : serializable_hash
         Alba.encoder.call(hash)
       end

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -265,12 +265,30 @@ module Alba
       # Set key
       #
       # @param key [String, Symbol]
+      # @deprecated Use {#root_key} instead
       def key(key)
+        warn '[DEPRECATION] `key` is deprecated, use `root_key` instead.'
         @_key = key.respond_to?(:to_sym) ? key.to_sym : key
       end
 
+      # Set root key
+      #
+      # @param key [String, Symbol]
+      # @raise [NoMethodError] when key doesn't respond to `to_sym` method
+      def root_key(key)
+        @_key = key.to_sym
+      end
+
       # Set key to true
+      #
+      # @deprecated Use {#root_key!} instead
       def key!
+        warn '[DEPRECATION] `key!` is deprecated, use `root_key!` instead.'
+        @_key = true
+      end
+
+      # Set root key to true
+      def root_key!
         @_key = true
       end
 

--- a/test/alba_test.rb
+++ b/test/alba_test.rb
@@ -61,7 +61,7 @@ class AlbaTest < Minitest::Test
   def test_it_serializes_object_with_block_with_with_option
     assert_equal(
       '{"foo":{"id":1,"articles":[{"title":"Hello World!","body":"Hello World!!!"}]}}',
-      Alba.serialize(@user, key: :foo) do
+      Alba.serialize(@user, root_key: :foo) do
         attributes :id
         many :articles do
           attributes :title, :body
@@ -73,7 +73,7 @@ class AlbaTest < Minitest::Test
   def test_it_serializes_object_with_fully_inlined_definitions
     assert_equal(
       '{"foo":{"id":1,"profile":{"email":"test@example.com"},"articles":[{"title":"Hello World!","body":"Hello World!!!"}]}}',
-      Alba.serialize(@user, key: :foo) do
+      Alba.serialize(@user, root_key: :foo) do
         attributes :id
         one :profile do
           attributes :email
@@ -90,7 +90,7 @@ class AlbaTest < Minitest::Test
 
     assert_equal(
       '{"foo":{"id":1,"articles":[{"title":"Hello World!","body":"Hello World!!!"}]}}',
-      Alba.serialize(@user, key: :foo) do
+      Alba.serialize(@user, root_key: :foo) do
         attributes :id
         many :articles do
           attributes :title, :body
@@ -106,7 +106,7 @@ class AlbaTest < Minitest::Test
 
       assert_equal(
         '{"foo":{"id":1,"articles":[{"title":"Hello World!","body":"Hello World!!!"}]}}',
-        Alba.serialize(@user, key: :foo) do
+        Alba.serialize(@user, root_key: :foo) do
           attributes :id
           many :articles do
             attributes :title, :body
@@ -121,7 +121,7 @@ class AlbaTest < Minitest::Test
 
     assert_equal(
       '{"foo":{"id":1,"articles":[{"title":"Hello World!","body":"Hello World!!!"}]}}',
-      Alba.serialize(@user, key: :foo) do
+      Alba.serialize(@user, root_key: :foo) do
         attributes :id
         many :articles do
           attributes :title, :body
@@ -134,7 +134,7 @@ class AlbaTest < Minitest::Test
     Alba.backend = :oj_strict
     assert_equal(
       '{"foo":{"id":1}}',
-      Alba.serialize(@user, key: :foo) do
+      Alba.serialize(@user, root_key: :foo) do
         attributes :id
       end
     )
@@ -144,7 +144,7 @@ class AlbaTest < Minitest::Test
     Alba.backend = :oj_rails
     assert_equal(
       '{"foo":{"id":1}}',
-      Alba.serialize(@user, key: :foo) do
+      Alba.serialize(@user, root_key: :foo) do
         attributes :id
       end
     )
@@ -177,7 +177,7 @@ class AlbaTest < Minitest::Test
     )
     assert_equal(
       '{"user":{"id":1,"articles":[{"title":"Hello World!","body":"Hello World!!!"}]}}',
-      Alba.serialize(@user, key: :user)
+      Alba.serialize(@user, root_key: :user)
     )
   end
 

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -16,7 +16,7 @@ class ResourceTest < MiniTest::Test
 
   class FooResource
     include Alba::Resource
-    key :foo
+    root_key :foo
     attributes :id
     many :bars, resource: BarResource
   end

--- a/test/usecases/circular_association_test.rb
+++ b/test/usecases/circular_association_test.rb
@@ -160,7 +160,7 @@ class CircularAssociationTest < Minitest::Test
 
   def test_within_option_works_for_serialize_with_collection
     books = @books.sample(3)
-    result = JSON.parse(BookResource.new(books, within: {authors: :books, genre: :books}).serialize(key: :books))
+    result = JSON.parse(BookResource.new(books, within: {authors: :books, genre: :books}).serialize(root_key: :books))
     assert books = result['books']
     assert books[0]['authors'][0]['books']
     refute books[0]['authors'][0]['books'][0]['authors']

--- a/test/usecases/circular_association_test.rb
+++ b/test/usecases/circular_association_test.rb
@@ -59,7 +59,7 @@ class CircularAssociationTest < Minitest::Test
   class AuthorResource
     include Alba::Resource
 
-    key!
+    root_key!
 
     attributes :id, :first_name, :last_name
     has_many :books, resource: 'CircularAssociationTest::BookResource'
@@ -68,7 +68,7 @@ class CircularAssociationTest < Minitest::Test
   class GenreResource
     include Alba::Resource
 
-    key!
+    root_key!
 
     attributes :id, :title, :description
     has_many :books, resource: 'CircularAssociationTest::BookResource'
@@ -77,7 +77,7 @@ class CircularAssociationTest < Minitest::Test
   class BookResource
     include Alba::Resource
 
-    key!
+    root_key!
 
     attributes :id, :title, :description, :published_at
     has_many :authors, resource: 'CircularAssociationTest::AuthorResource'

--- a/test/usecases/collection_test.rb
+++ b/test/usecases/collection_test.rb
@@ -49,7 +49,7 @@ class CollectionTest < Minitest::Test
   def test_array
     assert_equal(
       '{"users":[{"id":1,"articles":[{"title":"Hello World!"}]},{"id":2,"articles":[{"title":"Super nice"}]}]}',
-      UserResource.new([@user1, @user2]).serialize(key: :users)
+      UserResource.new([@user1, @user2]).serialize(root_key: :users)
     )
   end
 

--- a/test/usecases/key_transform_test.rb
+++ b/test/usecases/key_transform_test.rb
@@ -40,7 +40,7 @@ class KeyTransformTest < Minitest::Test
   class BankAccountResource
     include Alba::Resource
 
-    key!
+    root_key!
 
     attributes :account_number
     transform_keys :dash

--- a/test/usecases/no_association_test.rb
+++ b/test/usecases/no_association_test.rb
@@ -98,18 +98,15 @@ class NoAssociationTest < MiniTest::Test
     )
   end
 
-  def test_it_returns_correct_json_with_with_option_in_serialize_method
+  def test_it_returns_correct_json_with_with_root_key_option_to_serialize_method
     assert_equal(
       '{"user":{"id":1,"name":"Masafumi OKURA","name_with_email":"Masafumi OKURA: masafumi@example.com"}}',
-      UserResource.new(@user).serialize(key: :user)
+      UserResource.new(@user).serialize(root_key: :user)
     )
   end
 
-  def test_it_returns_correct_json_with_with_option_in_serialize_method_while_overwriting_default_serializer
-    assert_equal(
-      '{"user":{"id":1,"name":"Masafumi OKURA","name_with_email":"Masafumi OKURA: masafumi@example.com"}}',
-      UserResource.new(@user).serialize(key: :user)
-    )
+  def test_it_prints_warnings_when_key_option_is_given_to_serialize
+    assert_output('', "`key` option to `serialize` method is deprecated, use `root_key` instead.\n") { UserResource.new(@user).serialize(key: :user) }
   end
 
   class UserResource2
@@ -123,21 +120,21 @@ class NoAssociationTest < MiniTest::Test
   def test_attribute_works_without_block_args
     assert_equal(
       '{"user":{"name_with_email":"Masafumi OKURA: masafumi@example.com"}}',
-      UserResource2.new(@user).serialize(key: :user)
+      UserResource2.new(@user).serialize(root_key: :user)
     )
   end
 
   def test_serialiaze_method_with_option_as_proc
     assert_equal(
       '{"user":{"id":1,"name":"Masafumi OKURA","name_with_email":"Masafumi OKURA: masafumi@example.com"}}',
-      UserResource.new(@user).serialize(key: :user)
+      UserResource.new(@user).serialize(root_key: :user)
     )
   end
 
   def test_serialiaze_method_with_option_and_key_is_true
     assert_equal(
       '{"true":{"id":1,"name":"Masafumi OKURA","name_with_email":"Masafumi OKURA: masafumi@example.com"}}',
-      UserResource.new(@user).serialize(key: true)
+      UserResource.new(@user).serialize(root_key: true)
     )
   end
 
@@ -150,7 +147,7 @@ class NoAssociationTest < MiniTest::Test
   def test_serializer_key_overwrites_resource_key
     assert_equal(
       '{"user":{"id":1}}',
-      UserResourceWithKey.new(@user).serialize(key: :user)
+      UserResourceWithKey.new(@user).serialize(root_key: :user)
     )
   end
 

--- a/test/usecases/no_association_test.rb
+++ b/test/usecases/no_association_test.rb
@@ -47,6 +47,46 @@ class NoAssociationTest < MiniTest::Test
     )
   end
 
+  def test_it_prints_warnings_when_key_is_called
+    assert_output('', "[DEPRECATION] `key` is deprecated, use `root_key` instead.\n") do
+      Class.new do
+        include Alba::Resource
+
+        key :foo
+      end
+    end
+  end
+
+  def test_it_prints_warnings_when_key_bang_is_called
+    assert_output('', "[DEPRECATION] `key!` is deprecated, use `root_key!` instead.\n") do
+      Class.new do
+        include Alba::Resource
+
+        key!
+      end
+    end
+  end
+
+  def test_it_does_not_print_warnings_when_root_key_is_called
+    assert_silent do
+      Class.new do
+        include Alba::Resource
+
+        root_key :foo
+      end
+    end
+  end
+
+  def test_it_does_not_print_warnings_when_root_key_bang_is_called
+    assert_silent do
+      Class.new do
+        include Alba::Resource
+
+        root_key!
+      end
+    end
+  end
+
   def test_it_returns_correct_json_with_with_option_in_serialize_method
     assert_equal(
       '{"user":{"id":1,"name":"Masafumi OKURA","name_with_email":"Masafumi OKURA: masafumi@example.com"}}',

--- a/test/usecases/no_association_test.rb
+++ b/test/usecases/no_association_test.rb
@@ -87,6 +87,17 @@ class NoAssociationTest < MiniTest::Test
     end
   end
 
+  class UserResourceWithRootKey < UserResource
+    root_key :user, :users
+  end
+
+  def test_it_returns_json_with_second_argument_to_root_key_as_key_for_collection
+    assert_equal(
+      '{"users":[{"id":1,"name":"Masafumi OKURA","name_with_email":"Masafumi OKURA: masafumi@example.com"}]}',
+      UserResourceWithRootKey.new([@user]).serialize
+    )
+  end
+
   def test_it_returns_correct_json_with_with_option_in_serialize_method
     assert_equal(
       '{"user":{"id":1,"name":"Masafumi OKURA","name_with_email":"Masafumi OKURA: masafumi@example.com"}}',

--- a/test/usecases/no_association_test.rb
+++ b/test/usecases/no_association_test.rb
@@ -24,7 +24,7 @@ class NoAssociationTest < MiniTest::Test
   end
 
   class UserResourceWithKeyOnly < UserResource
-    key :user
+    root_key :user
   end
 
   def setup
@@ -144,7 +144,7 @@ class NoAssociationTest < MiniTest::Test
   class UserResourceWithKey
     include Alba::Resource
     attributes :id
-    key :not_user
+    root_key :not_user
   end
 
   def test_serializer_key_overwrites_resource_key

--- a/test/usecases/on_error_test.rb
+++ b/test/usecases/on_error_test.rb
@@ -22,7 +22,7 @@ class OnErrorTest < MiniTest::Test
   class UserResource
     include Alba::Resource
 
-    key :user
+    root_key :user
 
     attributes :id, :name, :email
   end

--- a/test/usecases/params_test.rb
+++ b/test/usecases/params_test.rb
@@ -37,7 +37,7 @@ class ParamsTest < MiniTest::Test
 
   class UserResource
     include Alba::Resource
-    key :user
+    root_key :user
 
     attributes :id, :name
 
@@ -68,7 +68,7 @@ class ParamsTest < MiniTest::Test
 
   class UserResource2
     include Alba::Resource
-    key :user
+    root_key :user
 
     attributes :id
 

--- a/test/usecases/user_defined_serializable_hash_test.rb
+++ b/test/usecases/user_defined_serializable_hash_test.rb
@@ -26,7 +26,7 @@ class UserDefinedSerializableHashTest < MiniTest::Test
     foo4 = Foo.new(4, 'name4')
     assert_equal(
       '{"foos":{"odd":[{"name":"name1"},{"name":"name3"}],"even":[{"name":"name2"},{"name":"name4"}]}}',
-      FooResource.new([foo1, foo2, foo3, foo4]).serialize(key: :foos)
+      FooResource.new([foo1, foo2, foo3, foo4]).serialize(root_key: :foos)
     )
   end
 end

--- a/test/usecases/with_inference_test.rb
+++ b/test/usecases/with_inference_test.rb
@@ -37,7 +37,7 @@ class WithInferenceTest < Minitest::Test
   class UserResource
     include Alba::Resource
 
-    key!
+    root_key!
 
     attributes :id
 
@@ -47,7 +47,7 @@ class WithInferenceTest < Minitest::Test
   class BankAccountResource
     include Alba::Resource
 
-    key!
+    root_key!
 
     attributes :account_number
   end

--- a/test/usecases/with_inference_test.rb
+++ b/test/usecases/with_inference_test.rb
@@ -112,7 +112,7 @@ class WithInferenceTest < Minitest::Test
   def test_it_prioritize_serialize_arg_with_key_bang
     assert_equal(
       '{"foo":{"id":1,"articles":[{"title":"The title"}]}}',
-      UserResource.new(@user).serialize(key: :foo)
+      UserResource.new(@user).serialize(root_key: :foo)
     )
   end
 


### PR DESCRIPTION
## Added

- `Resource.root_key` and `Resource.root_key!`
- Ability to set key for collection via `root_key` second parameter
- `root_key` option to `Resource#serialize` and `Alba.serialize`

## Removed

None

## Changed

- Tests to use new `root_key` version

## Deprecated

- `Resource.key` and `Resource.key!` are now deprecated
- `key` option for `Resource#serialize` and `Alba.serialize` are also deprecated