### PR TITLE
benchmarks: fix commenter names in panko

### DIFF
--- a/benchmark/single_resource.rb
+++ b/benchmark/single_resource.rb
@@ -253,7 +253,7 @@ class PankoPostSerializer < Panko::Serializer
   has_many :comments, serializer: PankoCommentSerializer
 
   def commenter_names
-    object.comments.pluck(:name)
+    object.commenters.pluck(:name)
   end
 end
 


### PR DESCRIPTION
Hi!

I'm Panko author, I ran the benchmarks (thanks @jaydorsey for the PR) and saw that the output of `commenter_names` was `["name", "name"]`, looks like it was looking on the wrong association.

About the issue here - https://github.com/okuramasafumi/alba/pull/156#issuecomment-898986886, I'll investigate it and will make sure that `pg` won't be a required dependency.