### PR TITLE
[Fix] Alba now works with Struct

### DIFF
--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -225,8 +225,10 @@ module Alba
         end
       end
 
+      # Detect if object is a collection or not.
+      # When object is a Struct, it's Enumerable but not a collection
       def collection?
-        @object.is_a?(Enumerable)
+        @object.is_a?(Enumerable) && !@object.is_a?(Struct)
       end
     end
 

--- a/test/usecases/with_struct_test.rb
+++ b/test/usecases/with_struct_test.rb
@@ -1,0 +1,19 @@
+require_relative '../test_helper'
+
+class WithStructTest < MiniTest::Test
+  User = Struct.new(:id, :name)
+  private_constant :User
+
+  class UserResource
+    include Alba::Resource
+
+    attributes :id, :name
+  end
+
+  def test_it_works_with_struct
+    user = User.new(1, 'test')
+    assert_equal '{"id":1,"name":"test"}', UserResource.new(user).serialize
+    user2 = User.new(2, 'test2')
+    assert_equal '[{"id":1,"name":"test"},{"id":2,"name":"test2"}]', UserResource.new([user, user2]).serialize
+  end
+end


### PR DESCRIPTION
`Struct` is `Enumerable`, so Alba misunderstood that it's a collection.
Now Alba checks if it's NOT a `Struct` for being a collection.