### PR TITLE
[Doc] Remove a badge for Inch-CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![CI](https://github.com/okuramasafumi/alba/actions/workflows/main.yml/badge.svg)](https://github.com/okuramasafumi/alba/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/okuramasafumi/alba/branch/master/graph/badge.svg?token=3D3HEZ5OXT)](https://codecov.io/gh/okuramasafumi/alba)
 [![Maintainability](https://api.codeclimate.com/v1/badges/fdab4cc0de0b9addcfe8/maintainability)](https://codeclimate.com/github/okuramasafumi/alba/maintainability)
-[![Inline docs](http://inch-ci.org/github/okuramasafumi/alba.svg?branch=main)](http://inch-ci.org/github/okuramasafumi/alba)
 ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/okuramasafumi/alba)
 ![GitHub](https://img.shields.io/github/license/okuramasafumi/alba)
 


### PR DESCRIPTION
I understand that this was added to maintain the documentation, but it doesn't seem to be working correctly.

I did some research and it seems that the PR needs to be created and merged according to the following rules.
http://inch-pages.github.io/participate/?github

However, it is unclear whether the above maintenance will continue or not, so I have removed it. Please consider it.

It may be better for the owner to send it, but If you request me to do so, I can send PR to the above repo. In that case, please feel free to close this PR.