### PR TITLE
[Deprecate] `to_hash` is special method and should not be used

### DIFF
--- a/lib/alba/association.rb
+++ b/lib/alba/association.rb
@@ -1,6 +1,6 @@
 module Alba
   # Base class for `One` and `Many`
-  # Child class should implement `to_hash` method
+  # Child class should implement `to_h` method
   class Association
     attr_reader :object, :name
 

--- a/lib/alba/many.rb
+++ b/lib/alba/many.rb
@@ -9,13 +9,13 @@ module Alba
     # @param within [Hash] determines what associations to be serialized. If not set, it serializes all associations.
     # @param params [Hash] user-given Hash for arbitrary data
     # @return [Array<Hash>]
-    def to_hash(target, within: nil, params: {})
+    def to_h(target, within: nil, params: {})
       @object = target.public_send(@name)
       @object = @condition.call(@object, params) if @condition
       return if @object.nil?
 
       @resource = constantize(@resource)
-      @resource.new(@object, params: params, within: within).to_hash
+      @resource.new(@object, params: params, within: within).to_h
     end
   end
 end

--- a/lib/alba/one.rb
+++ b/lib/alba/one.rb
@@ -9,13 +9,13 @@ module Alba
     # @param within [Hash] determines what associations to be serialized. If not set, it serializes all associations.
     # @param params [Hash] user-given Hash for arbitrary data
     # @return [Hash]
-    def to_hash(target, within: nil, params: {})
+    def to_h(target, within: nil, params: {})
       @object = target.public_send(@name)
       @object = @condition.call(object, params) if @condition
       return if @object.nil?
 
       @resource = constantize(@resource)
-      @resource.new(object, params: params, within: within).to_hash
+      @resource.new(object, params: params, within: within).to_h
     end
   end
 end

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -67,7 +67,13 @@ module Alba
       def serializable_hash
         collection? ? @object.map(&converter) : converter.call(@object)
       end
-      alias to_hash serializable_hash
+      alias to_h serializable_hash
+
+      # @deprecated Use {#serializable_hash} instead
+      def to_hash
+        warn '[DEPRECATION] `to_hash` is deprecated, use `serializable_hash` instead.'
+        serializable_hash
+      end
 
       private
 
@@ -196,7 +202,7 @@ module Alba
         value = case attribute
                 when Symbol then object.public_send attribute
                 when Proc then instance_exec(object, &attribute)
-                when Alba::One, Alba::Many then yield_if_within(attribute.name.to_sym) { |within| attribute.to_hash(object, params: params, within: within) }
+                when Alba::One, Alba::Many then yield_if_within(attribute.name.to_sym) { |within| attribute.to_h(object, params: params, within: within) }
                 when TypedAttribute then attribute.value(object)
                 else
                   raise ::Alba::Error, "Unsupported type of attribute: #{attribute.class}"

--- a/test/deprecation_test.rb
+++ b/test/deprecation_test.rb
@@ -1,0 +1,61 @@
+require_relative 'test_helper'
+
+class DeprecationTest < MiniTest::Test
+  class User
+    attr_accessor :id, :name, :email
+
+    def initialize(id, name, email)
+      @id = id
+      @name = name
+      @email = email
+    end
+  end
+
+  class UserResource
+    include Alba::Resource
+
+    attributes :id, :name
+
+    attribute :name_with_email do |resource|
+      "#{resource.name}: #{resource.email}"
+    end
+  end
+
+  class UserResourceWithKeyOnly < UserResource
+    root_key :user
+  end
+
+  def setup
+    Alba.backend = nil
+
+    @user = User.new(1, 'Masafumi OKURA', 'masafumi@example.com')
+  end
+
+  def test_it_prints_deprecation_warning_when_key_is_called
+    assert_output('', /\[DEPRECATION\] `key` is deprecated, use `root_key` instead.\n/) do
+      Class.new do
+        include Alba::Resource
+
+        key :foo
+      end
+    end
+  end
+
+  def test_it_prints_deprecation_warning_when_key_bang_is_called
+    assert_output('', /\[DEPRECATION\] `key!` is deprecated, use `root_key!` instead.\n/) do
+      Class.new do
+        include Alba::Resource
+
+        key!
+      end
+    end
+  end
+
+  def test_it_prints_deprecation_warning_when_key_option_is_given_to_serialize
+    assert_output('', /`key` option to `serialize` method is deprecated, use `root_key` instead.\n/) { UserResource.new(@user).serialize(key: :user) }
+  end
+
+  def test_it_prints_deprecation_warning_with_to_hash
+    assert_output('', /\[DEPRECATION\] `to_hash` is deprecated, use `serializable_hash` instead./) { UserResource.new(@user).to_hash }
+  end
+end

--- a/test/usecases/nil_handler_test.rb
+++ b/test/usecases/nil_handler_test.rb
@@ -127,7 +127,7 @@ class NilHandlerTest < Minitest::Test
       when :age
         20
       when :profile
-        ProfileResource2.new(Profile.new(object.id, 'default@example.com')).to_hash
+        ProfileResource2.new(Profile.new(object.id, 'default@example.com')).serializable_hash
       else
         ''
       end

--- a/test/usecases/no_association_test.rb
+++ b/test/usecases/no_association_test.rb
@@ -47,26 +47,6 @@ class NoAssociationTest < MiniTest::Test
     )
   end
 
-  def test_it_prints_warnings_when_key_is_called
-    assert_output('', /\[DEPRECATION\] `key` is deprecated, use `root_key` instead.\n/) do
-      Class.new do
-        include Alba::Resource
-
-        key :foo
-      end
-    end
-  end
-
-  def test_it_prints_warnings_when_key_bang_is_called
-    assert_output('', /\[DEPRECATION\] `key!` is deprecated, use `root_key!` instead.\n/) do
-      Class.new do
-        include Alba::Resource
-
-        key!
-      end
-    end
-  end
-
   def test_it_does_not_print_warnings_when_root_key_is_called
     assert_silent do
       Class.new do
@@ -103,10 +83,6 @@ class NoAssociationTest < MiniTest::Test
       '{"user":{"id":1,"name":"Masafumi OKURA","name_with_email":"Masafumi OKURA: masafumi@example.com"}}',
       UserResource.new(@user).serialize(root_key: :user)
     )
-  end
-
-  def test_it_prints_warnings_when_key_option_is_given_to_serialize
-    assert_output('', /`key` option to `serialize` method is deprecated, use `root_key` instead.\n/) { UserResource.new(@user).serialize(key: :user) }
   end
 
   class UserResource2


### PR DESCRIPTION
`to_hash` is a special method that Ruby interpreter invokes when
the object should be treated as Hash.
For example, when we call methods having keyword arguments with
hash using double splat(`**`).

```ruby
method_with_kwargs(**object) # => object.to_hash is invoked
```

When `Alba::Resource` object's `to_hash` is called, it doesn't work.
To resolve this problem `to_hash` method must be deprecated.
`serializable_hash` is now aliased to `to_h`, that's OK.