### PR TITLE
[Deprecate] `ignoring` in favor of `attributes` overriding

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,9 +343,11 @@ Alba.serialize(something)
 
 Although this might be useful sometimes, it's generally recommended to define a class for Resource.
 
-### Inheritance and Ignorance
+### Inheritance and attributes filter
 
-You can `exclude` or `ignore` certain attributes using `ignoring`.
+You can filter out certain attributes by overriding `attributes` instance method. This is useful when you want to customize existing resource with inheritance.
+
+You can access raw attributes via `super` call. It returns a Hash whose keys are the name of the attribute and whose values are the body. Usually you need only keys to filter out, like below.
 
 ```ruby
 class Foo
@@ -365,7 +367,9 @@ class GenericFooResource
 end
 
 class RestrictedFooResource < GenericFooResource
-  ignoring :id, :body
+  def attributes
+    super.select { |key, _| key.to_sym == :name }
+  end
 end
 
 RestrictedFooResource.new(foo).serialize

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -141,7 +141,7 @@ module Alba
 
       def converter
         lambda do |object|
-          arrays = @_attributes.map do |key, attribute|
+          arrays = attributes.map do |key, attribute|
             key_and_attribute_body_from(object, key, attribute)
           rescue ::Alba::Error, FrozenError, TypeError
             raise
@@ -150,6 +150,12 @@ module Alba
           end
           arrays.compact.to_h
         end
+      end
+
+      # This is default behavior for getting attributes for serialization
+      # Override this method to filter certain attributes
+      def attributes
+        @_attributes
       end
 
       def key_and_attribute_body_from(object, key, attribute)
@@ -416,6 +422,7 @@ module Alba
       #
       # @param attributes [Array<String, Symbol>]
       def ignoring(*attributes)
+        Alba::Deprecation.warn '`ignoring` is deprecated now. Instead please use `attributes` instance method to filter out attributes.'
         attributes.each do |attr_name|
           @_attributes.delete(attr_name.to_sym)
         end

--- a/test/usecases/inheritance_and_ignorance_test.rb
+++ b/test/usecases/inheritance_and_ignorance_test.rb
@@ -18,11 +18,23 @@ class InheritanceAndIgnoranceTest < MiniTest::Test
   end
 
   class RestrictedFooResouce < GenericFooResource
-    ignoring :id, :body
+    def attributes
+      super.select { |key, _| key.to_sym == :name }
+    end
   end
 
   def test_it_ignores_attributes
     foo = Foo.new(1, 'my foo', 'my body')
     assert_equal '{"name":"my foo"}', RestrictedFooResouce.new(foo).serialize
+  end
+
+  if Alba::VERSION <= '2.0'
+    def test_using_ignoring_prints_warning
+      assert_output('', /`ignoring` is deprecated now. Instead please use `attributes` instance method to filter out attributes./) do
+        Class.new(GenericFooResource) do
+          ignoring :id
+        end
+      end
+    end
   end
 end

--- a/test/usecases/nested_array_and_hash_test.rb
+++ b/test/usecases/nested_array_and_hash_test.rb
@@ -34,7 +34,10 @@ class HashAttributeTest < MiniTest::Test
 
   class ExtendedFooResource < FooResource
     many :bars, resource: BarResource
-    ignoring :config
+
+    def attributes
+      @_attributes.reject { |key, _| key == :config }
+    end
   end
 
   def test_it_works_with_hash_attribute


### PR DESCRIPTION
Using `ignoring` deletes (not filters) attributes, that might
consequence some problems.
Now we can do filtering safely by overriding `attributes` method.