### PR TITLE
Use Object#send in order to increase performance

### DIFF
--- a/lib/alba/association.rb
+++ b/lib/alba/association.rb
@@ -29,7 +29,7 @@ module Alba
     # @param params [Hash] user-given Hash for arbitrary data
     # @return [Hash]
     def to_h(target, within: nil, params: {})
-      @object = target.public_send(@name)
+      @object = target.__send__(@name)
       @object = @condition.call(object, params) if @condition
       return if @object.nil?
 

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -41,7 +41,7 @@ module Alba
         @params = params.freeze
         @within = within
         @method_existence = {} # Cache for `respond_to?` result
-        DSLS.each_key { |name| instance_variable_set("@#{name}", self.class.public_send(name)) }
+        DSLS.each_key { |name| instance_variable_set("@#{name}", self.class.__send__(name)) }
       end
 
       # Serialize object into JSON string
@@ -255,7 +255,7 @@ module Alba
       def fetch_attribute_from_object_and_resource(object, attribute)
         has_method = @method_existence[attribute]
         has_method = @method_existence[attribute] = object.respond_to?(attribute) if has_method.nil?
-        has_method ? object.public_send(attribute) : __send__(attribute, object)
+        has_method ? object.__send__(attribute) : __send__(attribute, object)
       end
 
       def nil_handler

--- a/lib/alba/typed_attribute.rb
+++ b/lib/alba/typed_attribute.rb
@@ -26,7 +26,7 @@ module Alba
     private
 
     def check(object)
-      value = object.public_send(@name)
+      value = object.__send__(@name)
       type_correct = case @type
                      when :String, ->(klass) { klass == String } then value.is_a?(String)
                      when :Integer, ->(klass) { klass == Integer } then value.is_a?(Integer)


### PR DESCRIPTION
Seems Object#send has the better performance then Object#public_send.

### Environment
- Kubuntu 21.10
- AMD Ryzen 7 5700G
- gcc version 11.2.0
- Ruby 3.1.1

#### Benchmark result
```
Warming up --------------------------------------
         Object#send     1.443M i/100ms
  Object#public_send     1.239M i/100ms
Calculating -------------------------------------
         Object#send     14.514M (± 1.9%) i/s -     73.585M in   5.071831s
  Object#public_send     12.476M (± 0.4%) i/s -     63.214M in   5.066893s

Comparison:
         Object#send: 14514416.9 i/s
  Object#public_send: 12476119.8 i/s - 1.16x  (± 0.00) slower
```

### Test code
```ruby
require 'benchmark/ips'

class Foo
  def foo
    123
  end
end

Benchmark.ips do |x|
  foo = Foo.new

  x.report('Object#send') {
    foo.send(:foo)
  }

  x.report('Object#public_send') {
    foo.public_send(:foo)
  }

  x.compare!
end
```