### PR TITLE
Use Hash to check given key whether it is supported

### DIFF
--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -16,6 +16,12 @@ module Alba
     CONDITION_UMNET = Object.new.freeze
     private_constant :CONDITION_UMNET
 
+    SUPPORTED_TRANSFORM_KEYS = %i[none snake camel lower_camel dash].each_with_object({}) do |elem, hash|
+      hash[elem] = true
+    end
+    SUPPORTED_TRANSFORM_KEYS.freeze
+    private_constant :SUPPORTED_TRANSFORM_KEYS
+
     # @private
     def self.included(base)
       super
@@ -420,7 +426,7 @@ module Alba
       # @raise [Alba::Error] when type is not supported
       def transform_keys(type, root: nil)
         type = type.to_sym
-        unless %i[none snake camel lower_camel dash].include?(type)
+        unless SUPPORTED_TRANSFORM_KEYS[type]
           # This should be `ArgumentError` but for backward compatibility it raises `Alba::Error`
           raise ::Alba::Error, "Unknown transform type: #{type}. Supported type are :camel, :lower_camel and :dash."
         end


### PR DESCRIPTION
Using Array#include?, it might have worse performance if the given key is in last element (or near).

### Environment
- Kubuntu 21.10
- AMD Ryzen 7 5700G
- gcc version 11.2.0
- Ruby 3.1.1

#### Benchmark result
```
Warming up --------------------------------------
Array#include? with first element
                         2.292M i/100ms
Array#include? with last element
                         1.395M i/100ms
Set#include? with first element
                         1.929M i/100ms
Set#include? with last element
                         1.812M i/100ms
Hash with first element
                         2.686M i/100ms
Hash with last element
                         2.589M i/100ms
Calculating -------------------------------------
Array#include? with first element
                         23.101M (± 0.4%) i/s -    116.912M in   5.060958s
Array#include? with last element
                         13.943M (± 0.7%) i/s -     69.755M in   5.003252s
Set#include? with first element
                         19.240M (± 0.6%) i/s -     96.473M in   5.014266s
Set#include? with last element
                         18.104M (± 0.7%) i/s -     90.583M in   5.003784s
Hash with first element
                         26.514M (± 1.0%) i/s -    134.307M in   5.065912s
Hash with last element
                         25.719M (± 1.1%) i/s -    129.433M in   5.033165s

Comparison:
Hash with first element: 26514405.6 i/s
Hash with last element: 25719127.1 i/s - 1.03x  (± 0.00) slower
Array#include? with first element: 23101025.9 i/s - 1.15x  (± 0.00) slower
Set#include? with first element: 19240456.7 i/s - 1.38x  (± 0.00) slower
Set#include? with last element: 18103779.5 i/s - 1.46x  (± 0.00) slower
Array#include? with last element: 13942781.3 i/s - 1.90x  (± 0.00) slower
```

### Test code
```ruby
require 'benchmark/ips'
require 'set'

Benchmark.ips do |x|
  A_KEYS = %i[none snake camel lower_camel dash]
  x.report('Array#include? with first element') {
    A_KEYS.include?(:none)
  }
  x.report('Array#include? with last element') {
    A_KEYS.include?(:dash)
  }

  S_KEYS = Set.new(%i[none snake camel lower_camel dash])
  x.report('Set#include? with first element') {
    S_KEYS.include?(:none)
  }
  x.report('Set#include? with last element') {
    S_KEYS.include?(:dash)
  }

  H_KEYS = %i[none snake camel lower_camel dash].reduce({}) { |h, k| h[k] = true; h }
  x.report('Hash with first element') {
    H_KEYS[:none]
  }
  x.report('Hash with last element') {
    H_KEYS[:dash]
  }

  x.compare!
end
```