### PR TITLE
Add `root_key_for_collection` in `Alba::Resource`

### DIFF
--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -372,6 +372,15 @@ module Alba
         @_key_for_collection = key_for_collection&.to_sym
       end
 
+      # Set root key for collection
+      #
+      # @param key [String, Symbol]
+      # @raise [NoMethodError] when key doesn't respond to `to_sym` method
+      def root_key_for_collection(key)
+        @_key = true
+        @_key_for_collection = key.to_sym
+      end
+
       # Set root key to true
       def root_key!
         @_key = true

--- a/test/usecases/root_key_collection_test.rb
+++ b/test/usecases/root_key_collection_test.rb
@@ -1,0 +1,33 @@
+require_relative '../test_helper'
+
+class RootKeyCollectionTest < Minitest::Test
+  class User
+    attr_reader :id, :name, :created_at, :updated_at
+
+    def initialize(id, name)
+      @id = id
+      @name = name
+      @created_at = Time.now
+      @updated_at = Time.now
+    end
+  end
+
+  class UserResource
+    include Alba::Resource
+
+    root_key_for_collection :users
+
+    attributes :id, :name
+  end
+
+  def setup
+    @users = [User.new(1, 'Masafumi OKURA'), User.new(2, 'heka1024')]
+  end
+
+  def test_root_key_collection
+    assert_equal(
+      '{"users":[{"id":1,"name":"Masafumi OKURA"},{"id":2,"name":"heka1024"}]}',
+      UserResource.new(@users).serialize
+    )
+  end
+end


### PR DESCRIPTION
# Motivation
- Close #195 
- Add fluent interface to set root key for collection

# Modification
- Add class method `root_key_for_collection` in `Alba::Resources`

# Result
You can now set root key for collection using `root_key_for_collection`
## Example
```ruby
class UserResource
  include Alba::Resource

  root_key_for_collection :users

  attributes :id, :name
end
```
```ruby
@users = [OpenStruct.new(id: 1, name: "heka1024")]
UserResource.new(@users).serialize 
# '{"users":[{"id":1,"name":"heka1024"}]}'