### PR TITLE
[Feat] Passing an initial object to proc function in associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,17 +261,18 @@ class AnotherUserResource
 end
 ```
 
-You can "filter" association using second proc argument. This proc takes association object and `params`.
+You can "filter" association using second proc argument. This proc takes association object, `params` and initial object.
 
 This feature is useful when you want to modify association, such as adding `includes` or `order` to ActiveRecord relations.
 
 ```ruby
 class User
-  attr_reader :id
+  attr_reader :id, :banned
   attr_accessor :articles
 
-  def initialize(id)
+  def initialize(id, banned = false)
     @id = id
+    @banned = banned
     @articles = []
   end
 end
@@ -299,9 +300,9 @@ class UserResource
 
   # Second proc works as a filter
   many :articles,
-    proc { |articles, params|
+    proc { |articles, params, user|
       filter = params[:filter] || :odd?
-      articles.select {|a| a.id.send(filter) }
+      articles.select {|a| a.id.send(filter) && !user.banned  }
     },
     resource: ArticleResource
 end

--- a/lib/alba/association.rb
+++ b/lib/alba/association.rb
@@ -30,7 +30,7 @@ module Alba
     # @return [Hash]
     def to_h(target, within: nil, params: {})
       @object = target.__send__(@name)
-      @object = @condition.call(object, params) if @condition
+      @object = @condition.call(object, params, target) if @condition
       return if @object.nil?
 
       @resource = constantize(@resource)

--- a/test/usecases/params_test.rb
+++ b/test/usecases/params_test.rb
@@ -79,7 +79,7 @@ class ParamsTest < MiniTest::Test
   end
 
   class UserResource3 < UserResource2
-    cond = lambda do |articles, params|
+    cond = proc do |articles, params|
       params[:foo] = true
       params[:foo] ? [] : articles
     end


### PR DESCRIPTION
Hey! This is my proposal with small enhancement for filter proc function. In rare cases it may be helpful to have an access to instance of the initial object(for example, to `User` instance in a `User <- Article` relation chain).

Please, see the tests for a synthetic example I've added there for what it may be used.