### PR TITLE
[Refactor] Extract conditional_attribute into a class

### DIFF
--- a/lib/alba/conditional_attribute.rb
+++ b/lib/alba/conditional_attribute.rb
@@ -1,0 +1,46 @@
+module Alba
+  # Represents attribute with `if` option
+  class ConditionalAttribute
+    CONDITION_UNMET = Object.new.freeze
+    public_constant :CONDITION_UNMET # It's public for use in `Alba::Resource`
+
+    # @param body [Symbol, Proc, Alba::Association, Alba::TypedAttribute] real attribute wrapped with condition
+    # @param condition [Symbol, Proc] condition to check
+    def initialize(body:, condition:)
+      @body = body
+      @condition = condition
+    end
+
+    # Returns attribute body if condition passes
+    #
+    # @param resource [Alba::Resource]
+    # @param object [Object] needed for collection, each object from collection
+    # @return [ConditionalAttribute::CONDITION_UNMET, Object] CONDITION_UNMET if condition is unmet, fetched attribute otherwise
+    def with_passing_condition(resource:, object: nil)
+      return CONDITION_UNMET unless condition_passes?(resource, object)
+
+      fetched_attribute = yield(@body)
+      if !fetched_attribute.nil? && @condition.is_a?(Proc) && @condition.arity >= 2
+        attr = @body.is_a?(Alba::Association) ? @body.object : fetched_attribute
+        return CONDITION_UNMET unless resource.instance_exec(object, attr, &@condition)
+      end
+      fetched_attribute
+    end
+
+    private
+
+    def condition_passes?(resource, object)
+      if @condition.is_a?(Proc)
+        arity = @condition.arity
+        # We can return early to skip fetch_attribute if arity is 1
+        # When arity is 2, we check the condition later
+        return true if arity >= 2
+        return false if arity <= 1 && !resource.instance_exec(object, &@condition)
+
+        true
+      else # Symbol
+        resource.__send__(@condition)
+      end
+    end
+  end
+end

--- a/test/usecases/conditional_attributes_test.rb
+++ b/test/usecases/conditional_attributes_test.rb
@@ -100,6 +100,10 @@ class ConditionalAttributesTest < MiniTest::Test
       '{"id":2}',
       UserResource1.new(user).serialize
     )
+    assert_equal(
+      '[{"id":1,"name":"Masafumi OKURA"},{"id":2}]',
+      UserResource1.new([@user, user]).serialize
+    )
   end
 
   def test_conditional_attribute_with_if
@@ -111,6 +115,10 @@ class ConditionalAttributesTest < MiniTest::Test
     assert_equal(
       '{"id":2}',
       UserResource2.new(user).serialize
+    )
+    assert_equal(
+      '[{"id":1,"username":"username"},{"id":2}]',
+      UserResource2.new([@user, user]).serialize
     )
   end
 


### PR DESCRIPTION
This might be good performance as well since we can now skip conditional check, but the main purpose of this change is readability.