### PR TITLE
initial proof of concept of a nested_hash method

### DIFF
--- a/lib/alba/association.rb
+++ b/lib/alba/association.rb
@@ -1,6 +1,10 @@
 module Alba
   # Representing association
   class Association
+    NESTED_HASH_NAME = Object.new.tap do |obj|
+      def obj.to_sym ; :__nested_hash__ ; end
+    end
+
     @const_cache = {}
     class << self
       attr_reader :const_cache
@@ -32,7 +36,7 @@ module Alba
     # @return [Hash]
     def to_h(target, within: nil, params: {})
       params = params.merge(@params) unless @params.empty?
-      @object = target.__send__(@name)
+      @object = @name != NESTED_HASH_NAME ? target.__send__(@name) : target
       @object = @condition.call(object, params, target) if @condition
       return if @object.nil?
 

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -307,6 +307,12 @@ module Alba
         @_attributes[name.to_sym] = options[:if] ? ConditionalAttribute.new(body: block, condition: options[:if]) : block
       end
 
+      def nested_hash(name, **options, &block)
+        assoc = Association.new(name: Association::NESTED_HASH_NAME, &block)
+        @_attributes[name.to_sym] = options[:if] ? [assoc, options[:if]] : assoc
+      end
+
+
       # Set association
       #
       # @param name [String, Symbol] name of the association, used as key when `key` param doesn't exist


### PR DESCRIPTION
A very simple proof of concept of the `nested_hash` concept we were talking about a bit in #233 

The implementation here isn't quite ready for merge, the way I make a special `Object.new` singleton with a `to_sym` method, to get around the `yield_if_within` call at https://github.com/okuramasafumi/alba/blob/bba0d91cfa4ad7e7f47a5874a6bd63dcf7c3cfd6/lib/alba/resource.rb#L209 ... is very hacky. 

But kind of amazing this can work with so few changes to code, leaning on the `Association` class? It is in fact very similar to an inline definition of a `one` association, just... without an association. 

No tests in the PR, but this works:

```ruby
person = OpenStruct.new(
  membership_number: 12988,
  member_name: "Terry Bradshaw",
  member_address1: "5555 West Test",
  member_city: "Miami",
  member_state: "FL"
)

class TestSerializer
  include Alba::Resource

  attribute :number, &:membership_number

  nested_hash :member do
   attribute :name, &:member_name
  end
end

TestSerializer.new(person).serializable_hash

# => {:number=>12988, :member=>{:name=>"Terry Bradshaw"}}

```


I know you may or may not be interested in this idea, but I got curious to see if I could make a proof of concept at least this afternoon, after realizing it might be very similar to an inline association resource, to see where I could get, and what you thought. 

(and still don't know about the name `nested_hash`. `nested_object`? `nest_object`?)