### PR TITLE
[Feat] Add `Resource#serialized_hash`

### DIFF
--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -50,16 +50,24 @@ module Alba
       # @param meta [Hash] metadata for this seialization
       # @return [String] serialized JSON string
       def serialize(root_key: nil, meta: {})
-        key = root_key.nil? ? fetch_key : root_key
-        hash = if key && key != :''
-                 h = {key.to_s => serializable_hash}
-                 hash_with_metadata(h, meta)
-               else
-                 serializable_hash
-               end
-        serialize_with(hash)
+        serialize_with(serialized_hash(root_key: root_key, meta: meta))
       end
       alias to_json serialize
+
+      # Serialize object into Hash
+      #
+      # @param root_key [Symbol, nil, true]
+      # @param meta [Hash] metadata for this seialization
+      # @return [Hash] serialized Hash
+      def serialized_hash(root_key: nil, meta: {})
+        key = root_key.nil? ? fetch_key : root_key
+        if key && key != :''
+          h = {key.to_s => serializable_hash}
+          hash_with_metadata(h, meta)
+        else
+          serializable_hash
+        end
+      end
 
       # A Hash for serialization
       #

--- a/test/usecases/no_association_test.rb
+++ b/test/usecases/no_association_test.rb
@@ -38,6 +38,10 @@ class NoAssociationTest < MiniTest::Test
       '{"id":1,"name":"Masafumi OKURA","name_with_email":"Masafumi OKURA: masafumi@example.com"}',
       UserResource.new(@user).serialize
     )
+    assert_equal(
+      {id: 1, name: 'Masafumi OKURA', name_with_email: 'Masafumi OKURA: masafumi@example.com'},
+      UserResource.new(@user).serialized_hash
+    )
   end
 
   def test_it_returns_correct_json_with_serializer_opt


### PR DESCRIPTION
While `serializable_hash` returns a Hash BEFORE adding a root key, `serialized_hash` return a Hash AFTER adding a root key. `serialized_hash` is a Hash version of `serialize` method.

We need to add a description to README.