### PR TITLE
README: add 'bundle exec' to a missing spot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1308,7 +1308,7 @@ There are great pioneers in Ruby's ecosystem which does basically the same thing
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 


### PR DESCRIPTION
...otherwise, you might have an error like I did!

```
$ rake test
rake aborted!
NoMethodError: undefined method `empty?' for nil:NilClass
/Users/trevorturk/Code/alba/Rakefile:4:in `<top (required)>'
(See full trace by running task with --trace)
```