### PR TITLE
CHANGELOG for breaking v2 change in serializable_hash/root_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ UserResource.new(user).serialize # => "{"user":{"id":1}}"
 UserResource.new(user).serializable_hash # => {"user"=>{:id=>1}}
 ```
 
-Note that v2 is now more consistent between the JSON and Ruby Hash implementations, but if you'd like to maintain the v1 behavior, you have two options.
+Note that v2 is now more consistent between the JSON and Ruby Hash outputs, but if you'd like to maintain the v1 behavior, you have two options.
 
 Option 1 is to pass `root_key: false` anywhere you want the old behavior:
 

--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ class BarResource < ApplicationResource
 end
 
 FooResource.new(foo).serialize # => '{"my_root_key":{"foo":1}}'
-BarResource.new(foo).serialize # => '{"my_root_key":{"bar":1}}'
+BarResource.new(bar).serialize # => '{"my_root_key":{"bar":1}}'
 ```
 
 This pattern is not required, but sometimes useful to make your resource classes DRY.


### PR DESCRIPTION
Re: #234 and #241

This PR moves the documentation for the breaking change in Alba v2 which may impact applications using `serializable_hash` (aliased as `to_h`) in conjunction with the `root_key` option from the README into the CHANGELOG. It also tweaks the `ApplicationResource` documentation example in the README slightly. 

Please feel free to move back into the README if preferred. My thinking was that the README should avoid being cluttered with explanations about breaking changes etc, which may take up more and more space over time and become confusing.

Apologies also for the long CHANGELOG entry, but I did my best to make the change as clear as possible. I also tested using `bin/console` (great feature!) to make sure the output matched my expectations and the documentation. 

One thing I would like to mention is that the `default_root_key` method was still a bit confusing to me, and I would suggest considering alternatives. To my mind, `default_root_key` seems oddly named, since the impact is that it excludes the `root_key` from `serializable_hash`.

Perhaps it may be worth considering a bang method which might help clarify what's going on since it'd be a well-named directive:

```ruby
class UserResource
  include Alba::Resource

  root_key :user
  exclude_root_key_from_ serializable_hash!

  attributes :id
end
```

...but I may be misunderstanding if there are further differences here, since `serializable_hash` now also takes `meta`, so please take this suggestion with a grain of salt.

Thanks for your consideration!