### PR TITLE
[Feat] Implement `as_json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
--  When using `Oj` with `object` mode, serialized root key is now something like ":foo" instead of "foo"
+- All Hash-related methods now return String key instead of Symbol key  
+    This affects all users, but you can use `deep_symbolize_keys` in Rails environment if you prefer Symbol keys
+    Some DSLs that take key argument such as `on_nil` and `on_error`, are also affected
 
 ## [1.6.0] 2022-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
+### Breaking changes
+
+-  When using `Oj` with `object` mode, serialized root key is now something like ":foo" instead of "foo"
+
 ## [1.6.0] 2022-03-16
 
 - [Feat] Support instance method as an attribute

--- a/README.md
+++ b/README.md
@@ -533,6 +533,15 @@ UserResource.new(user).serializable_hash
 UserResource.new(user).to_h
 ```
 
+If you want a Hash that corresponds to a JSON String returned by `serialize` method, you can use `as_json`.
+
+```ruby
+# These are equivalent and will return the same result
+UserResource.new(user).serialize
+UserResource.new(user).to_json
+JSON.generate(UserResource.new(user).as_json)
+```
+
 ### Inheritance
 
 When you include `Alba::Resource` in your class, it's just a class so you can define any class that inherits from it. You can add new attributes to inherited class like below:

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -50,16 +50,26 @@ module Alba
       # @param meta [Hash] metadata for this seialization
       # @return [String] serialized JSON string
       def serialize(root_key: nil, meta: {})
-        key = root_key.nil? ? fetch_key : root_key
-        hash = if key && key != :''
-                 h = {key.to_s => serializable_hash}
-                 hash_with_metadata(h, meta)
-               else
-                 serializable_hash
-               end
-        serialize_with(hash)
+        serialize_with(as_json(root_key: root_key, meta: meta))
       end
       alias to_json serialize
+
+      # Returns a Hash correspondng {Resource#serialize}
+      #
+      # @param root_key [Symbol, nil, true]
+      # @param meta [Hash] metadata for this seialization
+      # @param symbolize_root_key [Boolean] determines if root key should be symbolized
+      # @return [Hash]
+      def as_json(root_key: nil, meta: {})
+        key = root_key.nil? ? fetch_key : root_key
+        if key && key != :''
+          k = key.to_s.to_sym
+          h = {k => serializable_hash}
+          hash_with_metadata(h, meta)
+        else
+          serializable_hash
+        end
+      end
 
       # A Hash for serialization
       #

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -61,10 +61,9 @@ module Alba
       # @param symbolize_root_key [Boolean] determines if root key should be symbolized
       # @return [Hash]
       def as_json(root_key: nil, meta: {})
-        key = root_key.nil? ? fetch_key : root_key
-        if key && key != :''
-          k = key.to_s.to_sym
-          h = {k => serializable_hash}
+        key = root_key.nil? ? fetch_key : root_key.to_s
+        if key && !key.empty?
+          h = {key => serializable_hash}
           hash_with_metadata(h, meta)
         else
           serializable_hash
@@ -108,10 +107,10 @@ module Alba
         end
       end
 
-      # @return [Symbol]
+      # @return [String]
       def fetch_key
         k = collection? ? _key_for_collection : _key
-        transforming_root_key? ? transform_key(k) : k.to_sym
+        transforming_root_key? ? transform_key(k) : k
       end
 
       def _key_for_collection
@@ -200,7 +199,7 @@ module Alba
       # @return [Symbol]
       def transform_key(key) # rubocop:disable Metrics/CyclomaticComplexity
         key = key.to_s
-        return key.to_sym if @_transform_type == :none || key.empty? # We can skip transformation
+        return key if @_transform_type == :none || key.empty? # We can skip transformation
 
         inflector = Alba.inflector
         raise Alba::Error, 'Inflector is nil. You can set inflector with `Alba.enable_inference!(with: :active_support)` for example.' unless inflector
@@ -210,7 +209,7 @@ module Alba
         when :lower_camel then inflector.camelize_lower(key)
         when :dash then inflector.dasherize(key)
         when :snake then inflector.underscore(key)
-        end.to_sym
+        end
       end
 
       def fetch_attribute(object, key, attribute) # rubocop:disable Metrics/CyclomaticComplexity

--- a/test/alba_test.rb
+++ b/test/alba_test.rb
@@ -120,7 +120,7 @@ class AlbaTest < Minitest::Test
 
       Oj.default_options = {mode: :object}
       assert_equal(
-        '{":foo":{":id":1}}',
+        '{"foo":{"id":1}}',
         Alba.serialize(@user, root_key: :foo) do
           attributes :id
         end

--- a/test/alba_test.rb
+++ b/test/alba_test.rb
@@ -118,15 +118,15 @@ class AlbaTest < Minitest::Test
     def test_it_works_with_oj_default_backend
       Alba.backend = :oj_default
 
-      Oj.default_options = { mode: :object }
+      Oj.default_options = {mode: :object}
       assert_equal(
-        '{"foo":{":id":1}}',
+        '{":foo":{":id":1}}',
         Alba.serialize(@user, root_key: :foo) do
           attributes :id
         end
       )
 
-      Oj.default_options = { mode: :compat }
+      Oj.default_options = {mode: :compat}
       assert_equal(
         '{"foo":{"id":1}}',
         Alba.serialize(@user, root_key: :foo) do

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -35,14 +35,14 @@ class ResourceTest < MiniTest::Test
 
   def test_as_json
     assert_equal(
-      {foo: {id: 1, bar_size: 1, bars: [{id: 1}]}},
+      {'foo' => {'id' => 1, 'bar_size' => 1, 'bars' => [{'id' => 1}]}},
       FooResource.new(@foo).as_json
     )
   end
 
   def test_serializable_hash
     assert_equal(
-      {id: 1, bar_size: 1, bars: [{id: 1}]},
+      {'id' => 1, 'bar_size' => 1, 'bars' => [{'id' => 1}]},
       FooResource.new(@foo).serializable_hash
     )
   end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -25,15 +25,25 @@ class ResourceTest < MiniTest::Test
     end
   end
 
+  def setup
+    @foo = Foo.new
+    @foo.id = 1
+    @bar = Bar.new
+    @bar.id = 1
+    @foo.bars = [@bar]
+  end
+
+  def test_as_json
+    assert_equal(
+      {foo: {id: 1, bar_size: 1, bars: [{id: 1}]}},
+      FooResource.new(@foo).as_json
+    )
+  end
+
   def test_serializable_hash
-    foo = Foo.new
-    foo.id = 1
-    bar = Bar.new
-    bar.id = 1
-    foo.bars = [bar]
     assert_equal(
       {id: 1, bar_size: 1, bars: [{id: 1}]},
-      FooResource.new(foo).serializable_hash
+      FooResource.new(@foo).serializable_hash
     )
   end
 end

--- a/test/usecases/nil_handler_test.rb
+++ b/test/usecases/nil_handler_test.rb
@@ -113,7 +113,7 @@ class NilHandlerTest < Minitest::Test
 
   class ProfileResource2 < ProfileResource
     on_nil do |_object, key, _attribute|
-      if key == :full_name
+      if key == 'full_name'
         'Unknown'
       else
         ''
@@ -123,7 +123,7 @@ class NilHandlerTest < Minitest::Test
 
   class UserResource2 < UserResource
     on_nil do |object, key, _attribute|
-      case key
+      case key.to_sym
       when :age
         20
       when :profile


### PR DESCRIPTION
`as_json` returns a Hash like `serializable_hash`, but its result is similar to the result of `serialize`. In other words, `as_json` is a Hash version of `serialize`.
Since I changed the root key from String to Symbol, there's one breaking change that affects those who use Oj with `object` mode.