### PR TITLE
[Doc] Improve CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     This affects all users, but you can use `deep_symbolize_keys` in Rails environment if you prefer Symbol keys
     Some DSLs that take key argument such as `on_nil` and `on_error`, are also affected
 - Remove deprecated methods: `Resource#to_hash`, `Resource.ignoring`, `Alba.on_nil`, `Alba.on_error`, `Alba.enable_root_key_transformation!` and `Alba.disable_root_key_transformation!`
+- If using `transform_keys`, the default inflector is no longer set by default [d02245c8](https://github.com/okuramasafumi/alba/commit/d02245c87e9df303cb20e354a81e5457ea460bdd#diff-ecd8c835d2390b8cb89e7ff75e599f0c15cdbe18c30981d6090f4a515566686f)
+    To retain this functionality in Rails, add an initializer with the following:
+    `Alba.enable_inference!(with: :active_support)`
 
 ### New features
 


### PR DESCRIPTION
* Add note about the default inflector no longer being set automatically

When upgrading to Alba 2.0, I ran into this breaking change unexpectedly:

```
Alba::Error: Inflector is nil. You can set inflector with `Alba.enable_inference!(with: :active_support)` for example.
```

This PR adds to the CHANGELOG to highlight the issue and suggest a fix for a typical case in Rails.