### PR TITLE
[Doc] Tweak README to clarify inference/inflector configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Deprecate `inference` related methods in favor of a unified `inflector` interface.
+  Deprecated methods are `Alba.enable_inference!`, `Alba.disable_inference!`, and `Alba.inferring`.
+  Use `Alba.inflector = :active_support/:dry` or `Alba.inflector = SomeInflector` to enable.
+  Use `Alba.inflector = nil` to disable.
+  Use `Alba.inflector` to check if enabled.
+
 ## [2.0.0] 2022-10-21
 
 ### Breaking changes


### PR DESCRIPTION
When working on #258 I found the documentation to be a bit confusing. I tried to tidy things up a bit here with the following changes:

* Consolidate "inference" and "inference configuration" into one section
* Link to "inference configuration" when relevant
* Rename "inference" section and link it to "inference configuration"
* Prefer the word "inference" to the word "inflector" where possible

FWIW I still find the language a bit awkward. I was expecting Alba to expose a different API for configuring inference/inflection. Perhaps it's confusing because we configure the "inflector" for both "inflection" and "inference" but I'm not sure if it's worth making a big change. 

To illustrate a possible option, we could imagine changing the API from the first to the second:

```ruby
Alba.enable_inference!(with: :active_support)
Alba.inflector = :active_support
```

...and then you would be expected to set the `inflector` to enable both features. This might make sense since the gems Alba has built-in support for both use the term "inflector" in their names. 

Also re: #258 I understand the desire to remove the automatically-set inflector, but I personally preferred to have that set for me, since it meant I didn't need an initializer. 

In any case, feel free to discard this PR if you choose. I just wanted to provide some feedback for what I ran into when upgrading to Alba 2.0. Thank you!