### PR TITLE
[Fix] key transformation now cascades multiple levels

### DIFF
--- a/lib/alba.rb
+++ b/lib/alba.rb
@@ -69,7 +69,7 @@ module Alba
     def resource_class(&block)
       klass = Class.new
       klass.include(Alba::Resource)
-      klass.class_eval(&block)
+      klass.class_eval(&block) if block
       klass
     end
 

--- a/lib/alba/association.rb
+++ b/lib/alba/association.rb
@@ -20,10 +20,9 @@ module Alba
       @condition = condition
       @resource = resource
       @params = params
-      @key_transformation = key_transformation
       return if @resource
 
-      assign_resource(nesting, block)
+      assign_resource(nesting, key_transformation, block)
     end
 
     # Recursively converts an object into a Hash
@@ -58,9 +57,12 @@ module Alba
       end
     end
 
-    def assign_resource(nesting, block)
+    def assign_resource(nesting, key_transformation, block)
       @resource = if block
-                    Alba.resource_class(&block)
+                    klass = Alba.resource_class
+                    klass.transform_keys(key_transformation)
+                    klass.class_eval(&block)
+                    klass
                   elsif Alba.inferring
                     Alba.infer_resource_class(@name, nesting: nesting)
                   else
@@ -76,7 +78,6 @@ module Alba
 
     def to_h_with_constantize_resource(within, params)
       @resource = constantize(@resource)
-      @resource.transform_keys(@key_transformation)
       @resource.new(object, params: params, within: within).to_h
     end
   end

--- a/lib/alba/nested_attribute.rb
+++ b/lib/alba/nested_attribute.rb
@@ -10,8 +10,9 @@ module Alba
 
     # @return [Hash]
     def value(object)
-      resource_class = Alba.resource_class(&@block)
+      resource_class = Alba.resource_class
       resource_class.transform_keys(@key_transformation)
+      resource_class.class_eval(&@block)
       resource_class.new(object).serializable_hash
     end
   end

--- a/test/usecases/key_transform_test.rb
+++ b/test/usecases/key_transform_test.rb
@@ -173,11 +173,19 @@ class KeyTransformTest < Minitest::Test
     one :bank_account do
       attributes :account_number
     end
+
+    nested_attribute :fake_attribute do
+      nested_attribute :some_attribute do
+        attribute :real_attribute do
+          42
+        end
+      end
+    end
   end
 
   def test_key_transformation_cascades
     assert_equal(
-      '{"id":1,"firstName":"Masafumi","lastName":"Okura","bankAccount":{"accountNumber":123456789}}',
+      '{"id":1,"firstName":"Masafumi","lastName":"Okura","bankAccount":{"accountNumber":123456789},"fakeAttribute":{"someAttribute":{"realAttribute":42}}}',
       UserResourceWithInlineAssociation.new(@user).serialize
     )
   end


### PR DESCRIPTION
The cause of the bug was the usage of `Alba.assign_resource`, that evaluate given block and return the class object. So, when it's called, DSLs such as `attributes` are already evaluated. When we call `transform_keys` AFTER that call, `attributes` is assigned with empty key transformation configuration.
So I avoided this bug by not giving a block to `assign_resource` and call `transform_keys` and then call `class_eval` manually.

Fix #260 