### PR TITLE
[Deprecate] inference related APIs

### DIFF
--- a/lib/alba/association.rb
+++ b/lib/alba/association.rb
@@ -63,10 +63,10 @@ module Alba
                     klass.transform_keys(key_transformation)
                     klass.class_eval(&block)
                     klass
-                  elsif Alba.inferring
+                  elsif Alba.inflector
                     Alba.infer_resource_class(@name, nesting: nesting)
                   else
-                    raise ArgumentError, 'When Alba.inferring is false, either resource or block is required'
+                    raise ArgumentError, 'When Alba.inflector is nil, either resource or block is required'
                   end
     end
 

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -149,7 +149,7 @@ module Alba
       end
 
       def _key_for_collection
-        if Alba.inferring
+        if Alba.inflector
           @_key_for_collection == true ? resource_name(pluralized: true) : @_key_for_collection.to_s
         else
           @_key_for_collection == true ? raise_root_key_inference_error : @_key_for_collection.to_s
@@ -158,7 +158,7 @@ module Alba
 
       # @return [String]
       def _key
-        if Alba.inferring
+        if Alba.inflector
           @_key == true ? resource_name(pluralized: false) : @_key.to_s
         else
           @_key == true ? raise_root_key_inference_error : @_key.to_s
@@ -174,7 +174,7 @@ module Alba
       end
 
       def raise_root_key_inference_error
-        raise Alba::Error, 'You must call Alba.enable_inference! to set root_key to true for inferring root key.'
+        raise Alba::Error, 'You must set inflector when setting root key as true.'
       end
 
       def transforming_root_key?
@@ -237,7 +237,7 @@ module Alba
         return key if @_transform_type == :none || key.empty? # We can skip transformation
 
         inflector = Alba.inflector
-        raise Alba::Error, 'Inflector is nil. You can set inflector with `Alba.enable_inference!(with: :active_support)` for example.' unless inflector
+        raise Alba::Error, 'Inflector is nil. You must set inflector before transforming keys.' unless inflector
 
         case @_transform_type # rubocop:disable Style/MissingElse
         when :camel then inflector.camelize(key)

--- a/test/alba_test.rb
+++ b/test/alba_test.rb
@@ -214,7 +214,7 @@ class AlbaTest < Minitest::Test
   end
 
   def test_it_serializes_object_with_inferred_resource_when_inference_is_enabled
-    Alba.enable_inference!(with: :active_support)
+    Alba.inflector = :active_support
     assert_equal(
       '{"id":1,"articles":[{"title":"Hello World!","body":"Hello World!!!"}]}',
       Alba.serialize(@user)
@@ -223,11 +223,11 @@ class AlbaTest < Minitest::Test
       '{"user":{"id":1,"articles":[{"title":"Hello World!","body":"Hello World!!!"}]}}',
       Alba.serialize(@user, root_key: :user)
     )
-    Alba.disable_inference!
+    Alba.inflector = nil
   end
 
   def test_it_raises_error_when_trying_to_infer_resource_when_inference_is_disabled
-    Alba.disable_inference!
+    Alba.inflector = nil
     assert_raises(Alba::Error) { Alba.serialize(@user) }
   end
 
@@ -235,8 +235,28 @@ class AlbaTest < Minitest::Test
   end
 
   def test_it_raises_error_when_inferred_resource_does_not_exist_even_when_infernce_is_enabled
-    Alba.enable_inference!(with: :active_support)
+    Alba.inflector = :active_support
     assert_raises(NameError) { Alba.serialize(Foo.new) }
-    Alba.disable_inference!
+    Alba.inflector = nil
+  end
+
+  # Deprecated methods
+
+  def test_enable_inference_is_deprecated
+    assert_output(nil, /Alba.enable_inference! is deprecated. Use `Alba.inflector=` instead.\n/) do
+      Alba.enable_inference!(with: :active_support)
+    end
+  end
+
+  def test_disable_inference_is_deprecated
+    assert_output(nil, /Alba.disable_inference! is deprecated. Use `Alba.inflector = nil` instead.\n/) do
+      Alba.disable_inference!
+    end
+  end
+
+  def test_inferring_is_deprecated
+    assert_output(nil, /Alba.inferring is deprecated. Use `Alba.inflector` instead.\n/) do
+      Alba.inferring
+    end
   end
 end

--- a/test/dependencies/test_dependencies.rb
+++ b/test/dependencies/test_dependencies.rb
@@ -22,7 +22,7 @@ class DependenciesTest < MiniTest::Test
   end
 
   def teardown
-    Alba.disable_inference!
+    Alba.inflector = nil
     Alba.backend = nil
   end
 
@@ -31,7 +31,7 @@ class DependenciesTest < MiniTest::Test
       err = assert_raises(Alba::Error) do
         UserResourceCamel.new(@user).serialize
       end
-      assert_equal('Inflector is nil. You can set inflector with `Alba.enable_inference!(with: :active_support)` for example.', err.message)
+      assert_equal('Inflector is nil. You must set inflector before transforming keys.', err.message)
     end
 
     def test_it_warns_when_set_backend_as_active_support_but_active_support_is_not_available
@@ -50,7 +50,7 @@ class DependenciesTest < MiniTest::Test
       err = assert_raises(Alba::Error) do
         UserResourceWithRootKey.new(@user).serialize
       end
-      assert_equal('You must call Alba.enable_inference! to set root_key to true for inferring root key.', err.message)
+      assert_equal('You must set inflector when setting root key as true.', err.message)
     end
   elsif ENV['BUNDLE_GEMFILE'] == File.expand_path('gemfiles/without_oj.gemfile')
     def test_it_warns_when_set_backend_as_oj_but_oj_is_not_available

--- a/test/support/custom_inflector.rb
+++ b/test/support/custom_inflector.rb
@@ -1,0 +1,32 @@
+# Fake implementation of custom inflector
+module CustomInflector
+  module_function
+
+  def camelize(str)
+    "camelized_#{str}"
+  end
+
+  def camelize_lower(str)
+    str
+  end
+
+  def dasherize(str)
+    str
+  end
+
+  def classify(str)
+    str
+  end
+
+  def demodulize(str)
+    str.split('::').last
+  end
+
+  def underscore(str)
+    str.gsub(/::/, '/').gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').gsub(/([a-z\d])([A-Z])/, '\1_\2').tr('-', '_').downcase
+  end
+
+  def pluralize(str)
+    "#{str}s"
+  end
+end

--- a/test/usecases/circular_association_test.rb
+++ b/test/usecases/circular_association_test.rb
@@ -85,7 +85,7 @@ class CircularAssociationTest < Minitest::Test
   end
 
   def setup
-    Alba.enable_inference!(with: :active_support)
+    Alba.inflector = :active_support
 
     @authors = Array.new(100) do
       Author.new(
@@ -122,7 +122,7 @@ class CircularAssociationTest < Minitest::Test
   end
 
   def teardown
-    Alba.disable_inference!
+    Alba.inflector = nil
   end
 
   def test_within_option_works_for_serialize

--- a/test/usecases/key_transform_test.rb
+++ b/test/usecases/key_transform_test.rb
@@ -1,4 +1,5 @@
 require_relative '../test_helper'
+require_relative '../support/custom_inflector'
 
 class KeyTransformTest < Minitest::Test
   class User
@@ -64,14 +65,8 @@ class KeyTransformTest < Minitest::Test
     transform_keys :dash, root: false
   end
 
-  class CustomInflector
-    def camelize(key)
-      "camelized_#{key}"
-    end
-  end
-
   def setup
-    Alba.enable_inference!(with: :active_support)
+    Alba.inflector = :active_support
 
     @bank_account = BankAccount.new(123_456_789)
     @user = User.new(1, 'Masafumi', 'Okura', @bank_account)
@@ -143,7 +138,7 @@ class KeyTransformTest < Minitest::Test
   end
 
   def test_custom_inflector_is_used_if_defined
-    Alba.inflector = CustomInflector.new
+    Alba.inflector = CustomInflector
     assert_equal(
       '{"camelized_id":1,"camelized_first_name":"Masafumi","camelized_last_name":"Okura"}',
       UserResourceCamel.new(@user).serialize

--- a/test/usecases/many_test.rb
+++ b/test/usecases/many_test.rb
@@ -134,7 +134,7 @@ class ManyTest < MiniTest::Test
   end
 
   def test_it_raises_error_when_no_resource_or_block_given_without_inference
-    Alba.disable_inference!
+    Alba.inflector = nil
     resource = <<~RUBY
       class UserResource6
         include Alba::Resource

--- a/test/usecases/nested_attribute_test.rb
+++ b/test/usecases/nested_attribute_test.rb
@@ -27,13 +27,13 @@ class NestedAttributeTest < MiniTest::Test
 
   def setup
     Alba.backend = nil
-    Alba.enable_inference!(with: :active_support)
+    Alba.inflector = :active_support
 
     @user = User.new(1, 'Masafumi OKURA', 'masafumi@example.com', 'Tokyo', '0000000')
   end
 
   def teardown
-    Alba.disable_inference!
+    Alba.inflector = nil
   end
 
   def test_nested_attribute_becomes_nested_hash

--- a/test/usecases/one_test.rb
+++ b/test/usecases/one_test.rb
@@ -2,7 +2,7 @@ require_relative '../test_helper'
 
 class OneTest < MiniTest::Test
   def teardown
-    Alba.enable_inference!(with: :active_support)
+    Alba.inflector = :active_support
   end
 
   class User
@@ -159,17 +159,17 @@ class OneTest < MiniTest::Test
 
         one :profile
       end
-      OneTest.const_set('UserResource', klass)
+      OneTest.const_set(:UserResource, klass)
       klass
     end
   end
 
   def test_it_raises_error_when_no_resource_or_block_given_without_inference
-    Alba.disable_inference!
+    Alba.inflector = nil
     assert_raises(ArgumentError) { create_resource_class.call }
   end
 
-  Alba.enable_inference!(with: :active_support)
+  Alba.inflector = :active_support
   class UserResource7
     include Alba::Resource
 


### PR DESCRIPTION
Deprecated methods are:

* `Alba.enable_inference!`
* `Alba.disable_inference!`
* `Alba.inferring`

All APIs are now united to `Alba.inflector`, so:

* Use `Alba.inflector = SomeInflector` to set inflector
* Use `Alba.inflector = nil` to disable inference
* Use `Alba.inflector` to check if inference is enabled