### PR TITLE
Tweak CHANGELOG entry about Hash String keys change in 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
-- All Hash-related methods now return String key instead of Symbol key  
-    This affects all users, but you can use `deep_symbolize_keys` in Rails environment if you prefer Symbol keys
-    Some DSLs that take key argument such as `on_nil` and `on_error`, are also affected
+- All Hash-related methods now return String keys instead of Symbol keys.
+    This affects all users, but you can use `deep_symbolize_keys` in Rails environment if you prefer Symbol keys, or `with_indifferent_access` to support both String and Symbol keys.
+    Some DSLs that take key argument such as `on_nil` and `on_error`, are also affected.
 - Remove deprecated methods: `Resource#to_hash`, `Resource.ignoring`, `Alba.on_nil`, `Alba.on_error`, `Alba.enable_root_key_transformation!` and `Alba.disable_root_key_transformation!`
 - If using `transform_keys`, the default inflector is no longer set by default [d02245c8](https://github.com/okuramasafumi/alba/commit/d02245c87e9df303cb20e354a81e5457ea460bdd#diff-ecd8c835d2390b8cb89e7ff75e599f0c15cdbe18c30981d6090f4a515566686f)
     To retain this functionality in Rails, add an initializer with the following:


### PR DESCRIPTION
This is a very minor note, feel free to discard, but I think `with_indifferent_access` is another option instead of `deep_symbolize_keys` which I've seen used more widely, so I thought perhaps worth mentioning. I also added `.`s at the end of sentences, since I noticed the formatting is different when you view on GitHub so the sentences don't break. 