### PR TITLE
Allow ConditionalAttribute with 2-arity proc to reject nil attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,7 +798,7 @@ In these cases, conditional attributes works well. We can pass `if` option to `a
 
 ```ruby
 class User
-  attr_accessor :id, :name, :email, :created_at, :updated_at
+  attr_accessor :id, :name, :email
 
   def initialize(id, name, email)
     @id = id

--- a/lib/alba/conditional_attribute.rb
+++ b/lib/alba/conditional_attribute.rb
@@ -20,7 +20,7 @@ module Alba
       return Alba::REMOVE_KEY unless condition_passes?(resource, object)
 
       fetched_attribute = yield(@body)
-      return fetched_attribute if fetched_attribute.nil? || !with_two_arity_proc_condition
+      return fetched_attribute if !with_two_arity_proc_condition
 
       return Alba::REMOVE_KEY unless resource.instance_exec(object, attribute_from_association_body_or(fetched_attribute), &@condition)
 

--- a/test/usecases/conditional_attributes_test.rb
+++ b/test/usecases/conditional_attributes_test.rb
@@ -215,4 +215,19 @@ class ConditionalAttributesTest < MiniTest::Test
       UserResource11.new(@user).serialize
     )
   end
+
+  class UserResource12
+    include Alba::Resource
+
+    attributes :id, :name, if: proc { |_user, attribute| !attribute.nil? }
+  end
+
+  def test_conditional_attributes_with_if_for_nil_attributes
+    @user = User.new(1, nil)
+
+    assert_equal(
+      '{"id":1}',
+      UserResource12.new(@user).serialize
+    )
+  end
 end


### PR DESCRIPTION
I noticed that one of the examples in the README.md is currently not working as it claims to work.

This is the example:

```rb
class User
  attr_accessor :id, :name, :email, :created_at, :updated_at

  def initialize(id, name, email)
    @id = id
    @name = name
    @email = email
  end
end

class UserResource
  include Alba::Resource

  attributes :id, :name, :email, if: proc { |user, attribute| !attribute.nil? }
end

user = User.new(1, nil, nil)
UserResource.new(user).serialize # => '{"id":1}'
```

However, the last line of that example is inaccurate.

It currently does _not_ actually return this:

```rb
UserResource.new(user).serialize # => '{"id":1}'
```

It actually returns this:

```rb
UserResource.new(user).serialize # => '{"id":1,"name":null,"email":null}'
```

With the change made in this PR, that example now behaves as the README.md documentation claims that it does, i.e. it simply returns `'{"id":1}'`.