### PR TITLE
Fix README.md adding resource key when using proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ class UserResource
 
   attributes :id
 
-  many :articles, ->(article) { article.with_comment? ? ArticleWithCommentResource : ArticleResource }
+  many :articles, resource: ->(article) { article.with_comment? ? ArticleWithCommentResource : ArticleResource }
 end
 ```
 


### PR DESCRIPTION
Just a little fix in the `README.md` adding missing `resource` key when using proc in relationships.