### PR TITLE
Remove inch gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gemspec
 gem 'activesupport', require: false # For backend
 gem 'dry-inflector', require: false # For inflection
 gem 'ffaker', require: false # For testing
-gem 'inch', require: false # For inline documents
 gem 'minitest', '~> 5.14' # For test
 gem 'rake', '~> 13.0' # For test and automation
 gem 'rubocop', '>= 0.79.0', require: false # For lint


### PR DESCRIPTION
It seems `inch` project is abandoned. I saw the badge was removed more than one year ago, so, I don't think the gem is still needed.