### PR TITLE
Fix cascade not working with association and inheritance

### DIFF
--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -11,7 +11,7 @@ module Alba
   module Resource
     # @!parse include InstanceMethods
     # @!parse extend ClassMethods
-    DSLS = {_attributes: {}, _key: nil, _key_for_collection: nil, _meta: nil, _transform_type: :none, _transforming_root_key: false, _on_error: nil, _on_nil: nil, _layout: nil, _collection_key: nil}.freeze # rubocop:disable Layout/LineLength
+    DSLS = {_attributes: {}, _key: nil, _key_for_collection: nil, _meta: nil, _transform_type: :none, _transforming_root_key: false, _key_transformation_cascade: true, _on_error: nil, _on_nil: nil, _layout: nil, _collection_key: nil}.freeze # rubocop:disable Layout/LineLength
     private_constant :DSLS
 
     WITHIN_DEFAULT = Object.new.freeze

--- a/test/usecases/key_transform_test.rb
+++ b/test/usecases/key_transform_test.rb
@@ -199,4 +199,17 @@ class KeyTransformTest < Minitest::Test
       UserResourceWithInlineAssociationNoCascade.new(@user).serialize
     )
   end
+
+  class InheritedResource < UserResourceLowerCamel
+    one :bank_account do
+      attributes :account_number
+    end
+  end
+
+  def test_transform_key_with_inheritance
+    assert_equal(
+      '{"id":1,"firstName":"Masafumi","lastName":"Okura","bankAccount":{"accountNumber":123456789}}',
+      InheritedResource.new(@user).serialize
+    )
+  end
 end


### PR DESCRIPTION
This is because cascade setting is not inherited.
Now the default value is true and is inherited.
Fix #299 