### PR TITLE
[Feat] Add compatibility option for key

### DIFF
--- a/lib/alba.rb
+++ b/lib/alba.rb
@@ -107,10 +107,32 @@ module Alba
       const_parent.const_get("#{inflector.classify(name)}Resource")
     end
 
+    # Configure Alba to symbolize keys
+    def symbolize_keys!
+      @symbolize_keys = true
+    end
+
+    # Configure Alba to stringify (not symbolize) keys
+    def stringify_keys!
+      @symbolize_keys = false
+    end
+
+    # Regularize key to be either Symbol or String depending on @symbolize_keys
+    # Returns nil if key is nil
+    #
+    # @param key [String, Symbol, nil]
+    # @return [Symbol, String, nil]
+    def regularize_key(key)
+      return if key.nil?
+
+      @symbolize_keys ? key.to_sym : key.to_s
+    end
+
     # Reset config variables
     # Useful for test cleanup
     def reset!
       @encoder = default_encoder
+      @symbolize_keys = false
       @_on_error = :raise
       @_on_nil = nil
     end

--- a/test/alba_test.rb
+++ b/test/alba_test.rb
@@ -133,6 +133,16 @@ class AlbaTest < Minitest::Test
           attributes :id
         end
       )
+
+      Alba.symbolize_keys!
+      Oj.default_options = {mode: :object}
+      assert_equal(
+        '{":foo":{":id":1}}',
+        Alba.serialize(@user, root_key: :foo) do
+          attributes :id
+        end
+      )
+      Alba.stringify_keys!
     end
   end
 

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -38,6 +38,13 @@ class ResourceTest < MiniTest::Test
       {'foo' => {'id' => 1, 'bar_size' => 1, 'bars' => [{'id' => 1}]}},
       FooResource.new(@foo).as_json
     )
+
+    Alba.symbolize_keys!
+    assert_equal(
+      {foo: {id: 1, bar_size: 1, bars: [{id: 1}]}},
+      FooResource.new(@foo).as_json
+    )
+    Alba.stringify_keys!
   end
 
   def test_to_json


### PR DESCRIPTION
`Alba.symbolize_keys!` makes Alba to symbolize keys. `Alba.stringify_keys!` make Alba to stringify keys. The default is stringifying.

Close #303 