### PR TITLE
[Feat] It now infers resource name from Serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,20 @@ else
 end
 ```
 
+### Naming
+
+Alba tries to infer resource name from class name like the following.
+
+|Class name|Resource name|
+| --- | --- |
+| FooResource | Foo |
+| FooSerializer | Foo |
+| FooElse | FooElse |
+
+Resource name is used as the default name of the root key, so you might want to name it ending with "Resource" or "Serializer"
+
+When you use Alba with Rails, it's recommended to put your resource/serializer classes in corresponding directory such as `app/resources` or `app/serializers`.
+
 ### Simple serialization with root key
 
 You can define attributes with (yes) `attributes` macro with attribute names. If your attribute need some calculations, you can use `attribute` with block.

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -150,34 +150,24 @@ module Alba
       end
 
       def _key_for_collection
-        k = if Alba.inflector
-              @_key_for_collection == true ? resource_name(pluralized: true) : @_key_for_collection
-            else
-              @_key_for_collection == true ? raise_root_key_inference_error : @_key_for_collection
-            end
+        k = @_key_for_collection == true ? resource_name(pluralized: true) : @_key_for_collection
         Alba.regularize_key(k)
       end
 
       def _key
-        k = if Alba.inflector
-              @_key == true ? resource_name(pluralized: false) : @_key
-            else
-              @_key == true ? raise_root_key_inference_error : @_key
-            end
+        k = @_key == true ? resource_name(pluralized: false) : @_key
         Alba.regularize_key(k)
       end
 
       def resource_name(pluralized: false)
-        class_name = self.class.name
         inflector = Alba.inflector
+        raise Alba::Error, 'You must set inflector when setting root key as true.' unless inflector
+
+        class_name = self.class.name
         suffix = class_name.end_with?('Resource') ? 'Resource' : 'Serializer'
         name = inflector.demodulize(class_name).delete_suffix(suffix)
         underscore_name = inflector.underscore(name)
         pluralized ? inflector.pluralize(underscore_name) : underscore_name
-      end
-
-      def raise_root_key_inference_error
-        raise Alba::Error, 'You must set inflector when setting root key as true.'
       end
 
       def transforming_root_key?

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -170,7 +170,8 @@ module Alba
       def resource_name(pluralized: false)
         class_name = self.class.name
         inflector = Alba.inflector
-        name = inflector.demodulize(class_name).delete_suffix('Resource')
+        suffix = class_name.end_with?('Resource') ? 'Resource' : 'Serializer'
+        name = inflector.demodulize(class_name).delete_suffix(suffix)
         underscore_name = inflector.underscore(name)
         pluralized ? inflector.pluralize(underscore_name) : underscore_name
       end

--- a/test/usecases/key_transform_test.rb
+++ b/test/usecases/key_transform_test.rb
@@ -212,4 +212,15 @@ class KeyTransformTest < Minitest::Test
       InheritedResource.new(@user).serialize
     )
   end
+
+  class BankAccountRootSerializer < BankAccountRootResource
+    # Just changing suffix
+  end
+
+  def test_transform_key_to_lower_camel_works_on_root_key_when_root_option_set_to_true_with_serializer_suffix
+    assert_equal(
+      '{"bankAccountRoot":{"accountNumber":123456789}}',
+      BankAccountRootSerializer.new(@bank_account).serialize
+    )
+  end
 end


### PR DESCRIPTION
Resource name inference worked like below:

|Class name|Resource name|
| --- | --- |
| FooResource | Foo |
| FooSerializer | FooSerializer |
| FooElse | FooElse |

However we noticed that lots of users use the term `Serializer` and the current behavior is not convenient. It now works like below:

|Class name|Resource name|
| --- | --- |
| FooResource | Foo |
| FooSerializer | Foo |
| FooElse | FooElse |

It now deletes `Serializer` suffix as well.