### PR TITLE
[Feat] `Alba.serialize` is easier to use for multiple root keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,48 @@ Alba.serialize(something)
 
 Although this might be useful sometimes, it's generally recommended to define a class for Resource.
 
+#### Inline definition for multiple root keys
+
+While Alba doesn't directly support multiple root keys, you can simulate it with `Alba.serialize`.
+
+```ruby
+# Define foo and bar local variables here
+
+Alba.serialize do
+  attribute :key1 do
+    FooResource.new(foo).to_h
+  end
+
+  attribute :key2 do
+    BarResource.new(bar).to_h
+  end
+end
+# => JSON containing "key1" and "key2" as root keys
+```
+
+Note that we must use `to_h`, not `serialize`, with resources. 
+
+We can also generate a JSON with multiple root keys without making any class by the combination of `Alba.serialize` and `Alba.hashify`.
+
+```ruby
+# Define foo and bar local variables here
+
+Alba.serialize do
+  attribute :foo do
+    Alba.hashify(foo) do
+      attributes :id, :name # For example
+    end
+  end
+
+  attribute :bar do
+    Alba.hashify(bar) do
+      attributes :id
+    end
+  end
+end
+# => JSON containing "foo" and "bar" as root keys
+```
+
 ### Serializable Hash
 
 Instead of serializing to JSON, you can also output a Hash by calling `serializable_hash` or the `to_h` alias. Note also that the `serialize` method is aliased as `to_json`.

--- a/lib/alba.rb
+++ b/lib/alba.rb
@@ -44,11 +44,21 @@ module Alba
     # @param block [Block] resource block
     # @return [String] serialized JSON string
     # @raise [ArgumentError] if block is absent or `with` argument's type is wrong
-    def serialize(object, root_key: nil, &block)
-      klass = block ? resource_class(&block) : infer_resource_class(object.class.name)
-
-      resource = klass.new(object)
+    def serialize(object = nil, root_key: nil, &block)
+      resource = resource_with(object, &block)
       resource.serialize(root_key: root_key)
+    end
+
+    # Hashify the object with inline definitions
+    #
+    # @param object [Object] the object to be serialized
+    # @param root_key [Symbol, nil, true]
+    # @param block [Block] resource block
+    # @return [String] serialized JSON string
+    # @raise [ArgumentError] if block is absent or `with` argument's type is wrong
+    def hashify(object = nil, root_key: nil, &block)
+      resource = resource_with(object, &block)
+      resource.as_json(root_key: root_key)
     end
 
     # Enable inference for key and resource name
@@ -138,6 +148,13 @@ module Alba
     end
 
     private
+
+    # This method could be part of public API, but for now it's private
+    def resource_with(object, &block)
+      klass = block ? resource_class(&block) : infer_resource_class(object.class.name)
+
+      klass.new(object)
+    end
 
     def inflector_from(name_or_module)
       case name_or_module

--- a/test/alba_test.rb
+++ b/test/alba_test.rb
@@ -269,4 +269,23 @@ class AlbaTest < Minitest::Test
       Alba.inferring
     end
   end
+
+  def test_inline_serialization_for_multiple_root_keys
+    user = @user
+    profile = user.profile
+    assert_equal(
+      '{"key1":{"id":1,"articles":[{"title":"Hello World!","body":"Hello World!!!"}]},"key2":{"email":"test@example.com"}}',
+      Alba.serialize do
+        attribute :key1 do
+          UserResource.new(user).to_h
+        end
+
+        attribute :key2 do
+          Alba.hashify(profile) do
+            attributes :email
+          end
+        end
+      end
+    )
+  end
 end


### PR DESCRIPTION
It now works without `object` argument so that it's now easier to create a JSON with multiple root keys as described in README.
This commit also adds `Alba.hashify`, a Hash version of `Alba.serialize`. It's helpful used with `Alba.serialize`.