### PR TITLE
[Feat] Gives access to params in nested_attribute

### DIFF
--- a/lib/alba/nested_attribute.rb
+++ b/lib/alba/nested_attribute.rb
@@ -8,12 +8,14 @@ module Alba
       @block = block
     end
 
-    # @return [Hash]
-    def value(object)
+    # @param object [Object] the object being serialized
+    # @param params [Hash] params Hash inherited from Resource
+    # @return [Hash] hash serialized from running the class body in the object
+    def value(object:, params:)
       resource_class = Alba.resource_class
       resource_class.transform_keys(@key_transformation)
       resource_class.class_eval(&@block)
-      resource_class.new(object).serializable_hash
+      resource_class.new(object, params: params).serializable_hash
     end
   end
 end

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -255,7 +255,8 @@ module Alba
                 when Symbol then fetch_attribute_from_object_and_resource(obj, attribute)
                 when Proc then instance_exec(obj, &attribute)
                 when Alba::Association then yield_if_within(attribute.name.to_sym) { |within| attribute.to_h(obj, params: params, within: within) }
-                when TypedAttribute, NestedAttribute then attribute.value(obj)
+                when TypedAttribute then attribute.value(obj)
+                when NestedAttribute then attribute.value(object: obj, params: params)
                 when ConditionalAttribute then attribute.with_passing_condition(resource: self, object: obj) { |attr| fetch_attribute(obj, key, attr) }
                 else
                   raise ::Alba::Error, "Unsupported type of attribute: #{attribute.class}"

--- a/test/usecases/params_test.rb
+++ b/test/usecases/params_test.rb
@@ -174,4 +174,32 @@ class ParamsTest < MiniTest::Test
       AnotherUserResource.new(user).serialize
     )
   end
+
+  class UserResourceWithNestedAttribute
+    include Alba::Resource
+
+    root_key :user
+
+    nested :timestamps do
+      attribute :created_at do |user|
+        user.created_at.getlocal(params[:timezone_offset]).strftime('%H:%M')
+      end
+
+      attribute :updated_at do |user|
+        user.updated_at.getlocal(params[:timezone_offset]).strftime('%H:%M')
+      end
+    end
+  end
+
+  def test_params_goes_down_to_nested_attributes
+    user = User.new(1, 'Masafumi OKURA', 'test@example.org')
+
+    user_created_at_in_tz = user.created_at.getlocal('-20:00').strftime('%H:%M')
+    user_updated_at_in_tz = user.updated_at.getlocal('-20:00').strftime('%H:%M')
+
+    assert_equal(
+      "{\"user\":{\"timestamps\":{\"created_at\":\"#{user_created_at_in_tz}\",\"updated_at\":\"#{user_updated_at_in_tz}\"}}}",
+      UserResourceWithNestedAttribute.new(user, params: {timezone_offset: '-20:00'}).serialize
+    )
+  end
 end

--- a/test/usecases/params_test.rb
+++ b/test/usecases/params_test.rb
@@ -194,12 +194,12 @@ class ParamsTest < MiniTest::Test
   def test_params_goes_down_to_nested_attributes
     user = User.new(1, 'Masafumi OKURA', 'test@example.org')
 
-    user_created_at_in_tz = user.created_at.getlocal('-20:00').strftime('%H:%M')
-    user_updated_at_in_tz = user.updated_at.getlocal('-20:00').strftime('%H:%M')
+    user_created_at_in_tz = user.created_at.getlocal('-18:00').strftime('%H:%M')
+    user_updated_at_in_tz = user.updated_at.getlocal('-18:00').strftime('%H:%M')
 
     assert_equal(
       "{\"user\":{\"timestamps\":{\"created_at\":\"#{user_created_at_in_tz}\",\"updated_at\":\"#{user_updated_at_in_tz}\"}}}",
-      UserResourceWithNestedAttribute.new(user, params: {timezone_offset: '-20:00'}).serialize
+      UserResourceWithNestedAttribute.new(user, params: {timezone_offset: '-18:00'}).serialize
     )
   end
 end


### PR DESCRIPTION
I like the idea of nested attributes to organize the resources but one limitant factor is that they don't inherit the params object. This felt unexpected to me as the block passed to nested_attribute looks like it runs on the same scope as the rest of the resource.

Since it looked like a small change, i decided to try to do it myself. I tried to follow previous pull requests and other parts of the code. I would be happy to make any changes you think necessary (and it would also be fine if you end up closing it) as this PR is partially an exercise in contributing to open source. :slightly_smiling_face: 