### PR TITLE
Update README about `layout` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1338,12 +1338,12 @@ In case you don't want to have a file for layout, Alba lets you define and apply
 ```ruby
 class FooResource
   include Alba::Resource
-  layout inline: proc do
+  layout inline: proc {
     {
       header: 'my header',
       body: serializable_hash
     }
-  end
+  }
 end
 ```
 
@@ -1354,12 +1354,12 @@ You can also use a Proc which returns String, not a Hash, for an inline layout.
 ```ruby
 class FooResource
   include Alba::Resource
-  layout inline: proc do
+  layout inline: proc {
     %({
       "header": "my header",
       "body": #{serialized_json}
     })
-  end
+  }
 end
 ```
 


### PR DESCRIPTION
Hello,
I hope you are doing well. I wanted to bring to your attention that I encountered some issues while attempting to copy examples from the README. It was a bit surprising to find that they didn't work as expected. Specifically, when I tried the inline layout, I encountered an ArgumentError, and I tried to find any errors I might have made on my end.

---

```ruby
layout inline: proc do
  {
    header: "my header",
    body: serializable_hash
  }
end
```
raises the following error
```
ArgumentError
tried to create Proc object without a block
```
because of different precedence of `do..end` and `{..}`. So, either
```ruby
layout inline: proc {
  # code
}
```
or
```ruby
layout(inline: proc do
  # code
end)
```