### PR TITLE
Support access to `params` inside `nested` block

### DIFF
--- a/lib/alba/nested_attribute.rb
+++ b/lib/alba/nested_attribute.rb
@@ -15,6 +15,7 @@ module Alba
     def value(object:, params:)
       resource_class = Alba.resource_class
       resource_class.transform_keys(@key_transformation)
+      resource_class.define_singleton_method(:params) { params }
       resource_class.class_eval(&@block)
       resource_class.new(object, params: params).serializable_hash
     end

--- a/test/usecases/params_test.rb
+++ b/test/usecases/params_test.rb
@@ -202,4 +202,29 @@ class ParamsTest < MiniTest::Test
       UserResourceWithNestedAttribute.new(user, params: {timezone_offset: '-18:00'}).serialize
     )
   end
+
+  class ArticleResourceWithNestedAttribute
+    include Alba::Resource
+
+    nested :nested do
+      result_of_expensive_calculation = params[:salt] + 2
+
+      attribute :foo do
+        result_of_expensive_calculation
+      end
+
+      attribute :bar do |article|
+        result_of_expensive_calculation + article.body.size
+      end
+    end
+  end
+
+  def test_params_inside_nested_attributes
+    article = Article.new(1, "a", "b")
+
+    assert_equal(
+      "{\"nested\":{\"foo\":42,\"bar\":43}}",
+      ArticleResourceWithNestedAttribute.new(article, params: {salt: 40}).serialize
+    )
+  end
 end


### PR DESCRIPTION
# Motivation

In our usecase, we want to write code like below.

```ruby
class FooResource
  include Alba::Resource

  nested :foo do
    service = SomeService.new(params[:user])
    
    attribute :bar do |foo|
      service.bar
    end

    attribute :baz do |foo|
      service.baz
    end
  end
end
```

However, we can't do that because `params` is not available in the block.

# Modification
- Add `params` in the block of `nested` method.