### PR TITLE
Quote the 3.0 in GitHub action definition to avoid truncation. 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        ruby: [3.0, 3.1, 3.2, head, jruby, truffleruby]
+        ruby: ['3.0', 3.1, 3.2, head, jruby, truffleruby]
         gemfile: [all, without_active_support, without_oj]
         exclude:
           - os: windows-latest

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0, 3.1]
+        ruby: ['3.0', 3.1, 3.2]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -525,5 +525,3 @@ module Alba
   Serializer = Resource
   public_constant :Serializer
 end
-
-


### PR DESCRIPTION
The unquoted 3.0 in the set of Rubies being run is truncated to 3, which results in the latest Ruby 3 to be loaded in this case (currently 3.2.2).  That's not the intended behavior.  Quoting the 3.0 ensures that the desired Ruby 3.0.x version is run for this matrix entry.

Also removed extra blank lines that were causing the lint step to fail.  