### PR TITLE
[Fix] Resource method is those explicitly defined only

### DIFF
--- a/lib/alba/association.rb
+++ b/lib/alba/association.rb
@@ -57,7 +57,6 @@ module Alba
       when Class
         resource
       when Symbol, String
-        Object.const_get(resource)
         self.class.const_cache.fetch(resource) do
           self.class.const_cache[resource] = Object.const_get(resource)
         end

--- a/lib/alba/conditional_attribute.rb
+++ b/lib/alba/conditional_attribute.rb
@@ -51,6 +51,8 @@ module Alba
 
     # OpenStruct is used as a simple solution for converting Hash or Array of Hash into an object
     # Using OpenStruct is not good in general, but in this case there's no other solution
+    # rubocop:disable Style/OpenStructUse
+    # rubocop:disable Performance/OpenStruct
     def objectize(fetched_attribute)
       return fetched_attribute unless @body.is_a?(Alba::Association)
 
@@ -62,5 +64,7 @@ module Alba
         OpenStruct.new(fetched_attribute)
       end
     end
+    # rubocop:enable Style/OpenStructUse
+    # rubocop:enable Performance/OpenStruct
   end
 end

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -12,7 +12,7 @@ module Alba
   module Resource
     # @!parse include InstanceMethods
     # @!parse extend ClassMethods
-    INTERNAL_VARIABLES = {_attributes: {}, _key: nil, _key_for_collection: nil, _meta: nil, _transform_type: :none, _transforming_root_key: false, _key_transformation_cascade: true, _on_error: nil, _on_nil: nil, _layout: nil, _collection_key: nil, _helper: nil}.freeze # rubocop:disable Layout/LineLength
+    INTERNAL_VARIABLES = {_attributes: {}, _key: nil, _key_for_collection: nil, _meta: nil, _transform_type: :none, _transforming_root_key: false, _key_transformation_cascade: true, _on_error: nil, _on_nil: nil, _layout: nil, _collection_key: nil, _helper: nil, _resource_methods: []}.freeze # rubocop:disable Layout/LineLength
     private_constant :INTERNAL_VARIABLES
 
     WITHIN_DEFAULT = Object.new.freeze
@@ -265,9 +265,15 @@ module Alba
       end
 
       def _fetch_attribute_from_resource_first(obj, attribute)
-        __send__(attribute, obj)
-      rescue NoMethodError
-        obj.__send__(attribute)
+        if @_resource_methods.include?(attribute)
+          begin
+            __send__(attribute, obj)
+          rescue NoMethodError
+            obj.__send__(attribute)
+          end
+        else
+          obj.__send__(attribute)
+        end
       end
 
       def nil_handler
@@ -301,6 +307,12 @@ module Alba
     # Class methods
     module ClassMethods
       attr_reader(*INTERNAL_VARIABLES.keys)
+
+      # This `method_added` is used for defining "resource methods"
+      def method_added(method_name)
+        _resource_methods << method_name.to_sym unless method_name.to_sym == :_setup
+        super
+      end
 
       # @private
       def inherited(subclass)


### PR DESCRIPTION
For example, `params` method is on every Resource class, but they're not intended to be used as attribute.
So, `attributes :params` should work when `prefer_resource_method` is on.

Fix #342 #343 