### PR TITLE
[Fix] Only warn about `only` and `except` option

### DIFF
--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -96,12 +96,11 @@ module Alba
       private
 
       def _to_json(root_key, meta, options)
-        options.reject! { |k, _| %i[layout prefixes template status].include?(k) } # Rails specific guard
-        names = options.filter_map { |k, v| k unless v.nil? }
-        unless names.empty?
-          names.sort!
-          names.map! { |s| "\"#{s}\"" }
-          message = "You passed #{names.join(', ')} options but ignored. Please refer to the document: https://github.com/okuramasafumi/alba/blob/main/docs/rails.md"
+        confusing_options = options.keys.select { |k| k.to_sym == :only || k.to_sym == :except }
+        unless confusing_options.empty?
+          confusing_options.sort!
+          confusing_options.map! { |s| "\"#{s}\"" }
+          message = "You passed #{confusing_options.join(' and ')} options but ignored. Please refer to the document: https://github.com/okuramasafumi/alba/blob/main/docs/rails.md"
           Kernel.warn(message)
         end
         serialize(root_key: root_key, meta: meta)

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -75,8 +75,7 @@ class ResourceTest < Minitest::Test
         meta: {this: :meta}
       )
     end
-    message = "You passed \"except\", \"include\", \"methods\", \"only\", \"root\" options but ignored. Please refer to the document: https://github.com/okuramasafumi/alba/blob/main/docs/rails.md\n"
-    assert_output('', message) { result = execute2.call }
+    assert_output('', "You passed \"except\" and \"only\" options but ignored. Please refer to the document: https://github.com/okuramasafumi/alba/blob/main/docs/rails.md\n") { result = execute2.call }
     assert_equal(
       '{"foo":{"id":1,"bar_size":1,"bars":[{"id":1}]},"meta":{"this":"meta"}}',
       result


### PR DESCRIPTION
Fix #347 