### PR TITLE
Add ostruct as gemspec dependency to be prepared for ruby 3.3.5.

### DIFF
--- a/alba.gemspec
+++ b/alba.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+
+  s.add_dependency "ostruct", "~> 0.6"
 end

--- a/alba.gemspec
+++ b/alba.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  s.add_dependency "ostruct", "~> 0.6"
+  spec.add_dependency "ostruct", "~> 0.6"
 end


### PR DESCRIPTION
Hey,

with this fix, we supress the warning: 
```txt
/usr/local/bundle/gems/alba-3.2.0/lib/alba.rb:4: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```

best regards