### PR TITLE
Use Symbol#name to minimize memory allocation

### DIFF
--- a/lib/alba.rb
+++ b/lib/alba.rb
@@ -162,8 +162,9 @@ module Alba
     # @return [Symbol, String, nil]
     def regularize_key(key)
       return if key.nil?
+      return key.to_sym if @symbolize_keys
 
-      @symbolize_keys ? key.to_sym : key.to_s
+      key.is_a?(Symbol) ? key.name : key.to_s
     end
 
     # Transform a key with given transform_type


### PR DESCRIPTION
Ruby 3.0 introduced the `Symbol#name` method that acts as `Symbol#to_s` but returns a frozen string, we can utilize this method to reduce number of objects Alba creates during serialization.

BEFORE (no YJIT, no Oj):

```
IPS:

Comparison:
               panko:      692.4 i/s
alba_with_transformation:      276.5 i/s - 2.50x  slower
                alba:      240.7 i/s - 2.88x  slower
         alba_inline:       75.1 i/s - 9.21x  slower

MEMORY:

Comparison:
               panko:     259178 allocated
alba_with_transformation:     650141 allocated - 2.51x more
                alba:     826201 allocated - 3.19x more
         alba_inline:    2711921 allocated - 10.46x more
```

AFTER (no YJIT, no Oj):

```
IPS:

Comparison:
               panko:      668.5 i/s
alba_with_transformation:      276.8 i/s - 2.42x  slower
                alba:      264.6 i/s - 2.53x  slower
         alba_inline:       74.4 i/s - 8.99x  slower

MEMORY:

Comparison:
               panko:     259178 allocated
alba_with_transformation:     650141 allocated - 2.51x more
                alba:     650201 allocated - 2.51x more
         alba_inline:    2535921 allocated - 9.78x more
```
