### PR TITLE
Add `serializer` keyword argument as an alias for `resource`

### DIFF
--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -364,6 +364,7 @@ module Alba
       # @param name [String, Symbol] name of the association, used as key when `key` param doesn't exist
       # @param condition [Proc, nil] a Proc to modify the association
       # @param resource [Class<Alba::Resource>, String, Proc, nil] representing resource for this association
+      # @param serializer [Class<Alba::Resource>, String, Proc, nil] alias for `resource`
       # @param key [String, Symbol, nil] used as key when given
       # @param params [Hash] params override for the association
       # @param options [Hash<Symbol, Proc>]
@@ -371,7 +372,8 @@ module Alba
       # @param block [Block]
       # @return [void]
       # @see Alba::Association#initialize
-      def association(name, condition = nil, resource: nil, key: nil, params: {}, **options, &block)
+      def association(name, condition = nil, resource: nil, serializer: nil, key: nil, params: {}, **options, &block)
+        resource ||= serializer
         transformation = @_key_transformation_cascade ? @_transform_type : :none
         assoc = Association.new(
           name: name, condition: condition, resource: resource, params: params, nesting: nesting, key_transformation: transformation, helper: @_helper, &block

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -15,6 +15,7 @@ class ResourceTest < Minitest::Test
     include Alba::Resource
     attributes :id
   end
+  BarSerializer = BarResource
 
   class FooResource
     include Alba::Resource
@@ -111,7 +112,7 @@ class ResourceTest < Minitest::Test
     include Alba::Serializer
     root_key :foo
     attributes :id, :bar_size
-    many :bars, resource: BarResource
+    has_many :bars, serializer: BarSerializer
 
     def bar_size(foo)
       foo.bars.size


### PR DESCRIPTION
because we have `Serializer` alias here
https://github.com/okuramasafumi/alba/blob/d56583249521193471d27d453964c4665b876250/lib/alba/resource.rb#L547

i thought it would be cool if we can alias `serializer` as keyword argument for `resource` 😄
```ruby
class ApplicationSerializer
  include Alba::Serializer
end

class CustomerSerializer < ApplicationSerializer
  attributes :id, :name, :notes, :address, :contact, :updated_at
  has_many :invoices, serializer: InvoiceSerializer
  has_many :today_invoices, serializer: InvoiceSerializer
end
```