### PR TITLE
Optimize `set_key_and_attribute_body_from`

### DIFF
--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -216,7 +216,7 @@ module Alba
         value = fetch_attribute(obj, key, attribute)
         return unless select(key, value)
 
-        hash[key] = value unless value == Alba::REMOVE_KEY
+        hash[key] = value unless Alba::REMOVE_KEY == value # rubocop:disable Style/YodaCondition
       end
 
       def handle_error(error, obj, key, attribute, hash)


### PR DESCRIPTION
While profiling the bechmark, I noticed that unsurprisingly `set_key_and_attribute_body_from` is a hotspot.

What was surprising however is that it spends almost half its time in `String#==` and `Integer#==`.

This is caused by:

```ruby
unless value == Alba::REMOVE_KEY
```

Here `value` can be a lot of different types, whereas `REMOVE_KEY` is always the same instance of `Object`.

So there is two optimizations here, first we present the call site from being megamorphic, helping YJIT optimize it.

Second we ensure the `==` implementation used is always the `Object#==` which is a simple pointer comparison.

Before:

```
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                alba    53.000 i/100ms
Calculating -------------------------------------
                alba    483.567 (±28.7%) i/s    (2.07 ms/i) -      2.279k in   5.109508s
```

After:

```
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                alba    65.000 i/100ms
Calculating -------------------------------------
                alba    574.641 (±37.1%) i/s    (1.74 ms/i) -      2.535k in   5.061195s
```