### PR TITLE
Don't disable GC.

### DIFF
--- a/benchmark/collection.rb
+++ b/benchmark/collection.rb
@@ -242,7 +242,6 @@ simple_ams = Proc.new { SimpleAMS::Renderer::Collection.new(posts, serializer: S
 turbostreamer = Proc.new { TurbostreamerSerializer.new(posts).to_json }
 
 # --- Execute the serializers to check their output ---
-GC.disable
 puts "Checking outputs..."
 correct = alba.call
 parsed_correct = JSON.parse(correct)


### PR DESCRIPTION
I'm not sure why it was disabled, as [the associated PR has no justification](https://github.com/okuramasafumi/alba/pull/166). But I assume it was for speed or for more consistent results.

But Benchmark.ips takes care to run the code enough to know the margin of error.

As for speed, it actually makes the benchmark slower, because at some point allocating new pages is slower than letting the GC do its work.

Before:

```
                alba        466.635 (±34.7%) i/s    (2.14 ms/i) -      2.080k in   5.014043s
alba_with_transformation    393.942 (±21.6%) i/s    (2.54 ms/i) -      1.920k in   5.165633s
         alba_inline         17.251 (±23.2%) i/s   (57.97 ms/i) -     84.000 in   5.077454s
                 ams         32.664 (±18.4%) i/s   (30.62 ms/i) -    159.000 in   5.063782s
         blueprinter        180.512 (±70.4%) i/s    (5.54 ms/i) -    551.000 in   5.329223s
     fast_serializer        297.457 (±38.0%) i/s    (3.36 ms/i) -      1.080k in   5.223627s
         jserializer        443.939 (±44.6%) i/s    (2.25 ms/i) -      1.848k in   5.172605s
               panko          1.040k (±19.1%) i/s  (961.79 μs/i) -      5.117k in   5.159222s
               rails        200.887 (±49.3%) i/s    (4.98 ms/i) -    770.000 in   5.296745s
       representable        117.110 (±43.5%) i/s    (8.54 ms/i) -    368.000 in   5.381826s
          simple_ams        112.239 (±47.2%) i/s    (8.91 ms/i) -    264.000 in   5.467689s
       turbostreamer        496.180 (±52.6%) i/s    (2.02 ms/i) -      1.825k in   5.195224s
```

After:

```
                alba         674.108 (± 0.4%) i/s    (1.48 ms/i) -      3.417k in   5.069007s
alba_with_transformation     462.448 (± 0.6%) i/s    (2.16 ms/i) -      2.340k in   5.060184s
         alba_inline          17.353 (±17.3%) i/s   (57.63 ms/i) -     87.000 in   5.227311s
                 ams          37.851 (± 2.6%) i/s   (26.42 ms/i) -    192.000 in   5.073889s
         blueprinter         321.936 (± 1.6%) i/s    (3.11 ms/i) -      1.632k in   5.070438s
     fast_serializer         348.979 (± 2.0%) i/s    (2.87 ms/i) -      1.750k in   5.016493s
         jserializer         640.059 (± 1.1%) i/s    (1.56 ms/i) -      3.200k in   5.000129s
               panko           1.151k (± 1.0%) i/s  (868.93 μs/i) -      5.865k in   5.096864s
               rails         321.450 (± 1.9%) i/s    (3.11 ms/i) -      1.632k in   5.078804s
       representable         152.241 (± 0.7%) i/s    (6.57 ms/i) -    765.000 in   5.025254s
          simple_ams         127.256 (± 1.6%) i/s    (7.86 ms/i) -    648.000 in   5.094009s
       turbostreamer         833.976 (± 1.0%) i/s    (1.20 ms/i) -      4.182k in   5.014996s
```

But even if it helped with performance, it wouldn't be a good idea for a benchmark, because if some code has bad performance because it allocates a lot, well, the benchmark should show that.