### PR TITLE
Implement a fast path for `#attributes_to_hash`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
   file_list = ENV['BUNDLE_GEMFILE'] == File.expand_path('Gemfile') ? FileList['test/**/*_test.rb'] : FileList['test/dependencies/test_dependencies.rb']
   t.test_files = file_list
+  t.warning = true
 end
 
 task default: :test

--- a/lib/alba.rb
+++ b/lib/alba.rb
@@ -323,6 +323,9 @@ module Alba
 
     def reset_transform_keys
       @_transformed_keys = Hash.new { |h, k| h[k] = {} }
+      # FIXME: when inflector is changed, all resources `_attributes_hash` would need to be invalidated
+      # ObjectSpace.each_object works but is really dirty.
+      ObjectSpace.each_object(Class) { |k| k._clear_cache if k < Alba::Resource }
     end
 
     def register_default_types # rubocop:disable Metrics/AbcSize

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -125,4 +125,36 @@ class ResourceTest < Minitest::Test
       FooSerializer.new(@foo).to_json
     )
   end
+
+  class DeprecatedConverterResource
+    include Alba::Resource
+    attributes :id
+
+    private
+
+    def converter
+      ->(o) { o }
+    end
+  end
+
+  def test_deprecated_converter
+    assert_equal @foo, DeprecatedConverterResource.new(@foo).as_json
+  end
+
+  class DeprecatedConverterCollectionResource
+    include Alba::Resource
+    attributes :id
+
+    private
+
+    def collection_converter
+      lambda do |obj, a|
+        a << obj
+      end
+    end
+  end
+
+  def test_deprecated_collection_converter
+    assert_equal [@foo], DeprecatedConverterCollectionResource.new([@foo]).as_json
+  end
 end


### PR DESCRIPTION
This uses a number of performance tricks.

Rather than to call `transform_key` for every attribute of every instances, we do it once statically, and then use `transform_values` to fetch the values. This remove a big overhead, but is made a bit tricky as there are a number of global configurations that can invalidate that cache. I made it work, but things like using `ObjectSpace.each_object` isn't reasonable.

`Hash#transform_values` is also good because it allow Ruby to directly allocate a Hash of the right size, and skip the need to re-hash keys.
This doesn't make a big difference on the existing benchmark because there aren't many attributes, but I expect the gains would be more important the more attributes you have.

Makes `@_resource_methods` a Hash, so we can check whether we need to call the method on ourself or on `obj` in `O(1)`.

Inline the `Symbol` case for fetching attributes as it's the most common.
More cases could be inlined.

Specialize a fast path when `@_on_error` isn't set, because `rescue` clause cause an overhead (need to call `setjmp(3)`.
So it's best not to rescue when we don't have to.

Before:

```
ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
                alba    82.000 i/100ms
Calculating -------------------------------------
                alba    830.409 (± 0.8%) i/s    (1.20 ms/i) -      4.182k in   5.036433s
Calculating -------------------------------------
                alba   818.241k memsize (     0.000  retained)
                         9.807k objects (     0.000  retained)
                         6.000  strings (     0.000  retained)
```

After:

```
ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
                alba   107.000 i/100ms
Calculating -------------------------------------
                alba      1.074k (± 0.7%) i/s  (930.85 μs/i) -      5.457k in   5.079952s
Calculating -------------------------------------
                alba   818.241k memsize (     0.000  retained)
                         9.807k objects (     0.000  retained)
                         6.000  strings (     0.000  retained)
```

## Draft

Opening this as a draft because as noted above and in code comments, there are a number of Alba feature / flexibility that conflict a bit with this approach. So there would be some extra work needed to not break compatibility in some corner cases.

I mostly wanted to see how far we can theoretically go.

## Next Step?

After that, looking at the profile, the only significant gain left    I could think of would be to generate customized code for `attributes_to_hash` so that instead of relying on `__send__`, we could have regular method calls, hence help YJIT and the VM cache calls.