### PR TITLE
feat: add support for ignoring key when using proc for on_error

### DIFF
--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -273,7 +273,7 @@ module Alba
         when :ignore then nil
         when Proc
           key, value = on_error.call(error, obj, key, attribute, self.class)
-          hash[key] = value
+          hash[key] = value unless Alba::REMOVE_KEY == key # rubocop:disable Style/YodaCondition
         else
           # :nocov:
           raise Alba::Error, 'Impossible path'

--- a/test/usecases/on_error_test.rb
+++ b/test/usecases/on_error_test.rb
@@ -57,6 +57,12 @@ class OnErrorTest < Minitest::Test
     end
   end
 
+  class UserResourceForProcIgnoreKey < UserResource
+    on_error do |_error|
+      Alba::REMOVE_KEY
+    end
+  end
+
   def setup
     @user = User.new(1, 'Masafumi OKURA', 'masafumi@example.com')
   end
@@ -132,6 +138,13 @@ class OnErrorTest < Minitest::Test
     assert_equal(
       '{"user":{"id":1,"name":"Masafumi OKURA","error":"Error!"}}',
       UserResourceToChangeErrorKey.new(@user).serialize
+    )
+  end
+
+  def test_on_error_proc_ignore
+    assert_equal(
+      '{"user":{"id":1,"name":"Masafumi OKURA"}}',
+      UserResourceForProcIgnoreKey.new(@user).serialize
     )
   end
 end


### PR DESCRIPTION
## Why

Currently there is no way to use a proc for `on_error`, and ignore the key altogether.

A simple use case is wanting to log an error, and also ignoring the key in the output

```ruby
class MyResource
  include ::Alba::Resource

  on_error do |error, object, key, attribute, resource_class|
    Rails.logger.error("Error serializing #{resource_class.name} for #{object.class.name}:#{object.id}:#{key}:#{attribute}: #{error.message}")
    Alba::REMOVE_KEY
  end
end
```