### PR TITLE
[Fix] helpers are now available in NestedAttribute

### DIFF
--- a/lib/alba.rb
+++ b/lib/alba.rb
@@ -135,11 +135,15 @@ module Alba
       reset_transform_keys
     end
 
+    # @param helper [Module] helper module to include
+    # @param key_transformation [Symbol] key transformation type
     # @param block [Block] resource body
     # @return [Class<Alba::Resource>] resource class
-    def resource_class(&block)
+    def resource_class(helper: nil, key_transformation: :none, &block)
       klass = Class.new(resolved_default_superclass)
       klass.include(Alba::Resource)
+      klass.helper(helper) if helper
+      klass.transform_keys(key_transformation)
       klass.class_eval(&block) if block
       klass
     end

--- a/lib/alba/association.rb
+++ b/lib/alba/association.rb
@@ -101,20 +101,12 @@ module Alba
 
     def assign_resource(nesting, key_transformation, block, helper)
       @resource = if block
-                    charged_resource_class(helper, key_transformation, block)
+                    Alba.resource_class(helper: helper, key_transformation: key_transformation, &block)
                   elsif Alba.inflector
                     Alba.infer_resource_class(@name, nesting: nesting)
                   else
                     raise ArgumentError, 'When Alba.inflector is nil, either resource or block is required'
                   end
-    end
-
-    def charged_resource_class(helper, key_transformation, block)
-      klass = Alba.resource_class
-      klass.helper(helper) if helper
-      klass.transform_keys(key_transformation)
-      klass.class_eval(&block)
-      klass
     end
 
     def to_h_with_each_resource(object, within, params)

--- a/lib/alba/nested_attribute.rb
+++ b/lib/alba/nested_attribute.rb
@@ -7,9 +7,11 @@ module Alba
     # Setter for key_transformation, used when it's changed after class definition
     attr_writer :key_transformation
 
+    # @param klass [Class<Alba::Resource>] the parent for this nested attribute
     # @param key_transformation [Symbol] determines how to transform keys
     # @param block [Proc] class body
-    def initialize(key_transformation: :none, &block)
+    def initialize(klass:, key_transformation: :none, &block)
+      @klass = klass
       @key_transformation = key_transformation
       @block = block
     end
@@ -17,13 +19,13 @@ module Alba
     # @param object [Object] the object being serialized
     # @param params [Hash] params Hash inherited from Resource
     # @param within [Object, nil, false, true] determines what associations to be serialized. If not set, it serializes all associations.
-    # @param select [Method] select method object from its origin
     # @return [Hash] hash serialized from running the class body in the object
-    def value(object:, params:, within:, select: nil)
-      resource_class = Alba.resource_class
+    def value(object:, params:, within:)
+      resource_class = Class.new(@klass)
+      resource_class.instance_variable_set(:@_attributes, {}) # reset
       resource_class.transform_keys(@key_transformation)
       resource_class.class_eval(&@block)
-      resource_class.new(object, params: params, within: within, select: select).serializable_hash
+      resource_class.new(object, params: params, within: within).serializable_hash
     end
   end
 end

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -51,15 +51,13 @@ module Alba
       # @param within [Alba::WITHIN_DEFAULT, Hash, Array, nil, false, true]
       #   determines what associations to be serialized. If not set, it serializes all associations.
       # @param with_traits [Symbol, Array<Symbol>, nil] specified traits
-      # @param select [Method] select method object used with `nested_attribute` and `trait`
+      # @param select [Method] DEPRECATED noop
       def initialize(object, params: EMPTY_HASH, within: WITHIN_DEFAULT, with_traits: nil, select: nil)
         @object = object
         @params = params
         @within = within
         @with_traits = with_traits
-        # select override to share the same method with `trait` and `nested_attribute`
-        # Trait and NestedAttribute generates anonymous class so it checks if it's anonymous class to prevent accidental overriding
-        self.class.define_method(:select, &select) if select && self.class.name.nil?
+        warn '`select` keyword for Alba::Resource is deprecated', category: :deprecated, uplevel: 1 if select
         _setup
       end
 
@@ -125,7 +123,7 @@ module Alba
           resource_class.instance_variable_set(:@_attributes, {})
           resource_class.class_eval(&body)
           resource_class.transform_keys(@_transform_type) unless @_transform_type == :none
-          hash.merge!(resource_class.new(obj, params: params, within: @within, select: method(:select)).serializable_hash)
+          hash.merge!(resource_class.new(obj, params: params, within: @within).serializable_hash)
         end
       end
 
@@ -295,7 +293,7 @@ module Alba
                 when Proc then instance_exec(obj, &attribute)
                 when Alba::Association then yield_if_within(attribute.name.to_sym) { |within| attribute.to_h(obj, params: params, within: within) }
                 when TypedAttribute then attribute.value(object: obj) { |attr| fetch_attribute(obj, key, attr) }
-                when NestedAttribute then attribute.value(object: obj, params: params, within: @within, select: method(:select))
+                when NestedAttribute then attribute.value(object: obj, params: params, within: @within)
                 when ConditionalAttribute then attribute.with_passing_condition(resource: self, object: obj) { |attr| fetch_attribute(obj, key, attr) }
                   # :nocov:
                 else raise ::Alba::Error, "Unsupported type of attribute: #{attribute.class}"
@@ -489,7 +487,7 @@ module Alba
         raise ArgumentError, 'No block given in attribute method' unless block
 
         key_transformation = @_key_transformation_cascade ? @_transform_type : :none
-        attribute = NestedAttribute.new(key_transformation: key_transformation, &block)
+        attribute = NestedAttribute.new(klass: self, key_transformation: key_transformation, &block)
         @_attributes[name.to_sym] = options[:if] ? ConditionalAttribute.new(body: attribute, condition: options[:if]) : attribute
       end
       alias nested nested_attribute
@@ -634,7 +632,8 @@ module Alba
       # @return [void]
       def helper(mod = @_helper || Module.new, &block)
         mod.module_eval(&block) if block
-        extend mod
+        include(mod)
+        extend(mod)
 
         @_helper = mod
       end

--- a/sig/alba/nested_attribute.rbs
+++ b/sig/alba/nested_attribute.rbs
@@ -7,6 +7,7 @@ module Alba
     @block: Proc
 
     def initialize: (
+      klass: Class,
       ?key_transformation: Alba::transform_type
     ) { () -> void } -> void
 

--- a/test/usecases/nested_attribute_test.rb
+++ b/test/usecases/nested_attribute_test.rb
@@ -129,23 +129,76 @@ class NestedAttributeTest < Minitest::Test
     )
   end
 
-  # TODO: Fix this test
-  # class Bar3Resource
-  #   include Alba::Resource
-  #
-  #   nested_attribute :na do
-  #     attributes :some_value
-  #   end
-  #
-  #   def some_value(_object)
-  #     'From resource method'
-  #   end
-  # end
-  #
-  # def test_nested_attribute_with_resource_method
-  #   assert_equal(
-  #     '{"na":{"some_value":"From resource method"}}',
-  #     Bar3Resource.new(Bar.new('foo')).serialize
-  #   )
-  # end
+  module MyDSL
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def my_dsl_method(name)
+        # class-level DSL
+      end
+    end
+  end
+
+  class Bar4Resource
+    include Alba::Resource
+
+    helper MyDSL
+
+    nested :details do
+      my_dsl_method :baz # This should work
+      attributes :some_value
+    end
+  end
+
+  def test_class_method_style_helper_works_with_nested_attribute
+    assert_equal(
+      '{"details":{"some_value":"hello"}}',
+      Bar4Resource.new(Bar.new(:hello)).serialize
+    )
+  end
+
+  module SimpleHelper
+    def simple_dsl_method(name)
+      # class-level DSL
+    end
+  end
+
+  class Bar5Resource
+    include Alba::Resource
+
+    helper SimpleHelper
+
+    nested :details do
+      simple_dsl_method :baz # This should work
+      attributes :some_value
+    end
+  end
+
+  def test_helper_works_with_nested_attribute
+    assert_equal(
+      '{"details":{"some_value":"hello"}}',
+      Bar5Resource.new(Bar.new(:hello)).serialize
+    )
+  end
+
+  class Bar6Resource
+    include Alba::Resource
+
+    nested_attribute :na do
+      attributes :some_value
+    end
+
+    def some_value(_object)
+      'From resource method'
+    end
+  end
+
+  def test_nested_attribute_with_resource_method
+    assert_equal(
+      '{"na":{"some_value":"From resource method"}}',
+      Bar6Resource.new(Bar.new('foo')).serialize
+    )
+  end
 end


### PR DESCRIPTION
Fix #495 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resource classes can now be configured with helper modules and key transformations.
  * Helpers now work in nested attribute definitions using both DSL-style methods and resource-method usage.
* **Bug Fixes**
  * Improved nested attribute serialization so transformations and helper behavior are applied consistently.
* **Deprecation**
  * The `select` option is deprecated; it now only emits a warning and no longer impacts nested/trait serialization behavior.
* **Tests**
  * Expanded nested-attribute test coverage for helpers and resource-method-derived values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->