### PR TITLE
[Fix] Pass params to resource in serialize when with is given

### DIFF
--- a/lib/alba/railtie.rb
+++ b/lib/alba/railtie.rb
@@ -8,7 +8,7 @@ module Alba
 
       ActiveSupport.on_load(:action_controller) do
         define_method(:serialize) do |obj, params: {}, with: nil, root_key: nil, meta: {}, &block|
-          resource = with.nil? ? Alba.resource_for(obj, params: params, &block) : with.new(obj)
+          resource = with.nil? ? Alba.resource_for(obj, params: params, &block) : with.new(obj, params: params)
           resource.to_json(root_key: root_key, meta: meta)
         end
 

--- a/test/dependencies/railties_test.rb
+++ b/test/dependencies/railties_test.rb
@@ -49,12 +49,19 @@ class RailtiesTest < Minitest::Test
   class MyFoosController < ActionController::Base
     def show
       foo = Foo.new(1, 'foo')
-      render json: serialize(foo, params: nil, root_key: 'foo')
+      render json: serialize(foo, params: {include_special: true}, root_key: 'foo')
     end
 
     def index
       foo = Foo.new(1, 'foo')
       render_serialized_json([foo], params: {include_special: true}, with: FooResource, root_key: 'foos', meta: {total: 1})
+    end
+  end
+
+  class FoosWithResourceController < ActionController::Base
+    def show
+      foo = Foo.new(1, 'foo')
+      render json: serialize(foo, params: {include_special: true}, with: FooResource, root_key: 'foo')
     end
   end
 
@@ -113,13 +120,19 @@ class RailtiesTest < Minitest::Test
   def test_foos_controller_show_with_options
     controller = controller_instance(MyFoosController)
     controller.show
-    assert_equal '{"foo":{"id":1,"name":"foo"}}', controller.response_body.first
+    assert_equal '{"foo":{"id":1,"name":"foo","special":"special-foo"}}', controller.response_body.first
   end
 
   def test_foos_controller_index_with_options
     controller = controller_instance(MyFoosController)
     controller.index
     assert_equal '{"foos":[{"id":1,"name":"foo","special":"special-foo"}],"meta":{"total":1}}', controller.response_body.first
+  end
+
+  def test_serialize_with_resource_and_params
+    controller = controller_instance(FoosWithResourceController)
+    controller.show
+    assert_equal '{"foo":{"id":1,"name":"foo","special":"special-foo"}}', controller.response_body.first
   end
 
   private


### PR DESCRIPTION
## Summary

The `serialize` method in `Railtie` did not pass `params` to the resource when `with` was explicitly provided.
This was introduced in #509 where `render_serialized_json` correctly received the fix but `serialize` was missed.

```ruby
# Before (bug)
with.new(obj)

# After (fix)
with.new(obj, params: params)
```

Test changes

- MyFoosController#show: now tests serialize without with but with params to verify the Alba.resource_for path
- Added FoosWithResourceController to test serialize with both with and params to cover the fixed path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Serialization now automatically forwards request parameters to resource constructors, enabling conditional attribute inclusion in API responses based on request parameters. This allows developers to dynamically control which fields appear in serialized responses without requiring separate serialization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->