### PR TITLE
[Feat] Add configurable non_collection_types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `Alba.non_collection_types` for declaring Enumerable classes that should not be treated as collections [#532](https://github.com/okuramasafumi/alba/pull/532)
+
 ## 3.10.0 2025-11-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1927,16 +1927,18 @@ Don't forget calling `super` in this way.
 
 ### Treating specific classes as non-collection
 
-Sometimes we need to serialize an object that's `Enumerable` but not a collection. By default, Alba treats `Hash`, `Range` and `Struct` as non-collection object, but if we want to add some classes to this list, we can override `Alba.collection?` method like following:
+Sometimes we need to serialize an object that's `Enumerable` but not a collection. By default, Alba treats `Hash`, `Range` and `Struct` as non-collection objects. You can add additional classes to this list via `Alba.non_collection_types`:
 
 ```ruby
-Alba.singleton_class.prepend(
-  Module.new do
-    def collection?(object)
-      super && !object.is_a?(SomeClass)
-    end
-  end
-)
+Alba.non_collection_types << Stripe::StripeObject
+Alba.non_collection_types << MyEnumerableEntity
+```
+
+You can inspect the current set of excluded types (including the defaults) at any time:
+
+```ruby
+Alba.non_collection_types
+# => #<Set: {Struct, Range, Hash, Stripe::StripeObject, MyEnumerableEntity}>
 ```
 
 ### Adding indexes to `many` association

--- a/README.md
+++ b/README.md
@@ -1934,11 +1934,11 @@ Alba.non_collection_types << Stripe::StripeObject
 Alba.non_collection_types << MyEnumerableEntity
 ```
 
-You can inspect the current set of excluded types (including the defaults) at any time:
+You can inspect the current list of excluded types (including the defaults) at any time:
 
 ```ruby
 Alba.non_collection_types
-# => #<Set: {Struct, Range, Hash, Stripe::StripeObject, MyEnumerableEntity}>
+# => [Struct, Range, Hash, Stripe::StripeObject, MyEnumerableEntity]
 ```
 
 ### Adding indexes to `many` association

--- a/lib/alba.rb
+++ b/lib/alba.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'set'
 require_relative 'alba/version'
 require_relative 'alba/errors'
 require_relative 'alba/resource'
@@ -15,6 +16,9 @@ module Alba
 
     # Getter for inflector, a module responsible for inflecting strings
     attr_reader :inflector
+
+    # @return [Set] set of classes that include Enumerable but should not be treated as collections
+    attr_reader :non_collection_types
 
     # Set the backend, which actually serializes object into JSON
     #
@@ -79,11 +83,12 @@ module Alba
     end
 
     # Detect if object is a collection or not.
-    # When object is a Struct or a Range, it's Enumerable but not a collection
+    # Types in {.non_collection_types} (default: Struct, Range, Hash) are
+    # considered non-collection even if they include Enumerable.
     #
     # @api private
     def collection?(object)
-      object.is_a?(Enumerable) && !object.is_a?(Struct) && !object.is_a?(Range) && !object.is_a?(Hash)
+      object.is_a?(Enumerable) && @non_collection_types.none? { |type| object.is_a?(type) }
     end
 
     # Enable inference for key and resource name
@@ -219,6 +224,7 @@ module Alba
       @_on_error = :raise
       @_on_nil = nil
       @types = {}
+      @non_collection_types = Set[Struct, Range, Hash]
       reset_transform_keys
       register_default_types
     end

--- a/lib/alba.rb
+++ b/lib/alba.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'set'
 require_relative 'alba/version'
 require_relative 'alba/errors'
 require_relative 'alba/resource'
@@ -17,7 +16,7 @@ module Alba
     # Getter for inflector, a module responsible for inflecting strings
     attr_reader :inflector
 
-    # @return [Set] set of classes that include Enumerable but should not be treated as collections
+    # @return [Array<Class>] classes that include Enumerable but should not be treated as collections
     attr_reader :non_collection_types
 
     # Set the backend, which actually serializes object into JSON
@@ -224,7 +223,7 @@ module Alba
       @_on_error = :raise
       @_on_nil = nil
       @types = {}
-      @non_collection_types = Set[Struct, Range, Hash]
+      @non_collection_types = [Struct, Range, Hash]
       reset_transform_keys
       register_default_types
     end

--- a/test/alba_test.rb
+++ b/test/alba_test.rb
@@ -522,7 +522,7 @@ class AlbaTest < Minitest::Test
   def test_non_collection_types_resets_to_defaults
     Alba.non_collection_types << EnumerableSingleObject
     Alba.reset!
-    assert_equal Set[Struct, Range, Hash], Alba.non_collection_types
+    assert_equal [Struct, Range, Hash], Alba.non_collection_types
   end
 
   def test_serialize_custom_enumerable_as_single_object

--- a/test/alba_test.rb
+++ b/test/alba_test.rb
@@ -485,4 +485,56 @@ class AlbaTest < Minitest::Test
       end
     end
   end
+
+  class EnumerableSingleObject
+    include Enumerable
+
+    attr_reader :id, :name
+
+    def initialize(id, name)
+      @id = id
+      @name = name
+    end
+
+    def each
+      yield [:id, @id]
+      yield [:name, @name]
+    end
+  end
+
+  def test_non_collection_types_excludes_custom_enumerable
+    obj = EnumerableSingleObject.new(1, 'test')
+    assert Alba.collection?(obj)
+
+    Alba.non_collection_types << EnumerableSingleObject
+    refute Alba.collection?(obj)
+  ensure
+    Alba.reset!
+  end
+
+  def test_non_collection_types_does_not_affect_real_collections
+    Alba.non_collection_types << EnumerableSingleObject
+    assert Alba.collection?([1, 2, 3])
+  ensure
+    Alba.reset!
+  end
+
+  def test_non_collection_types_resets_to_defaults
+    Alba.non_collection_types << EnumerableSingleObject
+    Alba.reset!
+    assert_equal Set[Struct, Range, Hash], Alba.non_collection_types
+  end
+
+  def test_serialize_custom_enumerable_as_single_object
+    obj = EnumerableSingleObject.new(42, 'stripe_pm')
+    Alba.non_collection_types << EnumerableSingleObject
+
+    result = Alba.serialize(obj) do
+      attributes :id, :name
+    end
+
+    assert_equal '{"id":42,"name":"stripe_pm"}', result
+  ensure
+    Alba.reset!
+  end
 end


### PR DESCRIPTION
## Problem

Objects that include `Enumerable` but represent a single entity (e.g. `Stripe::StripeObject`, various API wrapper objects) are incorrectly treated as collections by `Alba.collection?`. This causes single-object serialization to break.

The current workaround documented in the README requires monkey-patching via `singleton_class.prepend`:

```ruby
Alba.singleton_class.prepend(Module.new do
  def collection?(object)
    super && !object.is_a?(Stripe::StripeObject)
  end
end)
```

This works but isn't discoverable as a configuration option and requires understanding Ruby's method resolution order.

## Solution

Add `Alba.non_collection_types`, a `Set` that users can append to declaratively:

```ruby
Alba.non_collection_types << Stripe::StripeObject
```

`collection?` now checks this set in addition to the hardcoded `Struct`/`Range`/`Hash` exclusions. The set is cleared by `Alba.reset!` to support test isolation.

This follows Alba's existing configuration style (class-level setters like `Alba.backend=`, `Alba.inflector=`) rather than introducing a `configure` block.

## Usage

```ruby
# In an initializer
Alba.non_collection_types << Stripe::StripeObject
Alba.non_collection_types << SomeOtherEnumerableWrapper

# Now single-object serialization works as expected
Alba.serialize(stripe_payment_method) do
  attributes :id, :type, :card
end
# => '{"id":"pm_123","type":"card","card":{...}}'
```

## Tests

Four new tests covering:
- Custom Enumerable excluded after adding to `non_collection_types`
- Real collections (Array) still detected correctly
- `reset!` clears the set
- End-to-end serialization of a custom Enumerable as a single object

Full suite passes (268 tests, 400 assertions, 0 failures).

Refs #397, #430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable set for treating specific Enumerable-like classes as non-collections so they serialize as single objects rather than arrays; reset restores defaults.

* **Tests**
  * Added coverage verifying custom registration, serialization behavior for registered types, and that reset restores the default excluded types.

* **Documentation**
  * Updated README and changelog to document the new configuration and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->