### PR TITLE
Apply traits once per resource rather than once per object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Traits are now applied once per resource class instead of once per serialized object, making an attribute in a trait cost the same as one declared inline
+  - A trait body is evaluated once per trait combination and the result is memoized, so side effects or runtime conditionals in a trait body no longer run on every serialization
+  - `transform_keys` inside a trait now applies to the whole output of the resource serialized with that trait, not only to the keys the trait defines
+
 ## 3.11.0 2026-07-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Traits are now applied once per resource class instead of once per serialized object, making an attribute in a trait cost the same as one declared inline
+  - A trait body is evaluated once per trait combination and the result is memoized, so side effects or runtime conditionals in a trait body no longer run on every serialization
+  - `transform_keys` inside a trait now applies to the whole output of the resource serialized with that trait, not only to the keys the trait defines
+
 ### Added
 
 - Add `Alba.non_collection_types` for declaring Enumerable classes that should not be treated as collections [#532](https://github.com/okuramasafumi/alba/pull/532)

--- a/benchmark/traits.rb
+++ b/benchmark/traits.rb
@@ -1,0 +1,93 @@
+# Benchmark script to measure what a trait costs.
+#
+# Each pair of resources below serializes exactly the same JSON, once with the attributes declared on the resource
+# and once with the very same attributes declared in a trait, so whatever separates the two is what the trait costs.
+
+require_relative 'prep'
+
+require 'alba'
+
+# --- Attributes on the resource ---
+
+class InlineCommentResource
+  include Alba::Resource
+  attributes :id, :body
+end
+
+class InlinePostResource
+  include Alba::Resource
+  attributes :id, :body
+  attribute(:commenter_names) { |post| post.commenters.pluck(:name) }
+  many :comments, resource: InlineCommentResource
+end
+
+# --- The same attributes, in a trait ---
+
+class TraitCommentResource
+  include Alba::Resource
+  attributes :id, :body
+end
+
+class TraitPostResource
+  include Alba::Resource
+  attributes :id, :body
+
+  trait :with_comments do
+    attribute(:commenter_names) { |post| post.commenters.pluck(:name) }
+    many :comments, resource: TraitCommentResource
+  end
+end
+
+# --- A trait carrying a plain attribute, which is where a resource pays the most for one ---
+
+class InlineBodySizeResource
+  include Alba::Resource
+  attributes :id, :body
+  attribute(:body_size) { |post| post.body.size }
+end
+
+class TraitBodySizeResource
+  include Alba::Resource
+  attributes :id, :body
+
+  trait :with_body_size do
+    attribute(:body_size) { |post| post.body.size }
+  end
+end
+
+# --- Test data creation ---
+
+100.times do |i|
+  post = Post.create!(body: "post#{i}")
+  user1 = User.create!(name: "John#{i}")
+  user2 = User.create!(name: "Jane#{i}")
+  10.times do |n|
+    post.comments.create!(commenter: user1, body: "Comment1_#{i}_#{n}")
+    post.comments.create!(commenter: user2, body: "Comment2_#{i}_#{n}")
+  end
+end
+
+posts = Post.all.includes(:comments, :commenters)
+
+inline_association = proc { InlinePostResource.new(posts).serialize }
+trait_association = proc { TraitPostResource.new(posts, with_traits: :with_comments).serialize }
+inline_attribute = proc { InlineBodySizeResource.new(posts).serialize }
+trait_attribute = proc { TraitBodySizeResource.new(posts, with_traits: :with_body_size).serialize }
+
+raise 'inline and trait must serialize the same JSON' unless inline_association.call == trait_association.call
+raise 'inline and trait must serialize the same JSON' unless inline_attribute.call == trait_attribute.call
+
+benchmark_body = lambda do |x|
+  x.report(:attribute_inline, &inline_attribute)
+  x.report(:attribute_trait, &trait_attribute)
+  x.report(:association_inline, &inline_association)
+  x.report(:association_trait, &trait_association)
+
+  x.compare!
+end
+
+require 'benchmark/ips'
+Benchmark.ips(&benchmark_body)
+
+require 'benchmark/memory'
+Benchmark.memory(&benchmark_body)

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -50,13 +50,11 @@ module Alba
       # @param params [Hash] user-given Hash for arbitrary data
       # @param within [Alba::WITHIN_DEFAULT, Hash, Array, nil, false, true]
       #   determines what associations to be serialized. If not set, it serializes all associations.
-      # @param with_traits [Symbol, Array<Symbol>, nil] specified traits
       # @param select [Method] DEPRECATED noop
-      def initialize(object, params: EMPTY_HASH, within: WITHIN_DEFAULT, with_traits: nil, select: nil)
+      def initialize(object, params: EMPTY_HASH, within: WITHIN_DEFAULT, select: nil)
         @object = object
         @params = params
         @within = within
-        @with_traits = with_traits
         warn '`select` keyword for Alba::Resource is deprecated', category: :deprecated, uplevel: 1 if select
         _setup
       end
@@ -113,19 +111,6 @@ module Alba
       alias to_h serializable_hash
 
       private
-
-      def hash_from_traits(obj)
-        return {} if @with_traits.nil?
-
-        Array(@with_traits).each_with_object({}) do |trait, hash|
-          body = @_traits.fetch(trait) { raise Alba::Error, "Trait not found: #{trait}" }
-          resource_class = Class.new(self.class)
-          resource_class.instance_variable_set(:@_attributes, {})
-          resource_class.class_eval(&body)
-          resource_class.transform_keys(@_transform_type) unless @_transform_type == :none
-          hash.merge!(resource_class.new(obj, params: params, within: @within).serializable_hash)
-        end
-      end
 
       def serialize_with(hash)
         serialized_json = encode(hash)
@@ -202,7 +187,7 @@ module Alba
         rescue StandardError => e
           handle_error(e, obj, key, attribute, hash)
         end
-        @with_traits.nil? ? hash : hash.merge!(hash_from_traits(obj))
+        hash
       end
 
       # Default implementation for selecting attributes
@@ -312,6 +297,34 @@ module Alba
     # Class methods
     module ClassMethods
       attr_reader(*INTERNAL_VARIABLES.keys)
+
+      # @param with_traits [Symbol, Array<Symbol>, nil] traits to apply, in the given order
+      # @raise [Alba::Error] when a trait is not defined on this resource
+      # @see InstanceMethods#initialize
+      def new(object, with_traits: nil, **kwargs)
+        return super(object, **kwargs) if with_traits.nil?
+
+        class_with_traits(Array(with_traits)).new(object, **kwargs)
+      end
+
+      # A subclass with the given traits applied, built once per trait combination.
+      def class_with_traits(traits)
+        classes = @_classes_with_traits || {}
+        @_classes_with_traits = classes
+        classes[traits] || (classes[traits.dup.freeze] = build_class_with_traits(traits))
+      end
+      private :class_with_traits
+
+      def build_class_with_traits(traits)
+        resource_class = Class.new(itself)
+        resource_name = name
+        resource_class.define_singleton_method(:name) { resource_name }
+        traits.each do |trait|
+          resource_class.class_eval(&@_traits.fetch(trait) { raise Alba::Error, "Trait not found: #{trait}" })
+        end
+        resource_class
+      end
+      private :build_class_with_traits
 
       # This `method_added` is used for defining "resource methods"
       def method_added(method_name)
@@ -527,6 +540,8 @@ module Alba
       # @see #transform_keys
       def transform_keys!(type)
         dup.class_eval do
+          # Class#dup copies the memo, whose classes were built with the old transform type
+          @_classes_with_traits = nil
           transform_keys(type, root: @_transforming_root_key, cascade: @_key_transformation_cascade)
 
           if @_key_transformation_cascade

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -468,6 +468,7 @@ module Alba
         raise ArgumentError, 'No block given in trait method' unless block
 
         name = name.to_sym
+        @_classes_with_traits = nil
         @_traits[name] = block
       end
 

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -50,13 +50,11 @@ module Alba
       # @param params [Hash] user-given Hash for arbitrary data
       # @param within [Alba::WITHIN_DEFAULT, Hash, Array, nil, false, true]
       #   determines what associations to be serialized. If not set, it serializes all associations.
-      # @param with_traits [Symbol, Array<Symbol>, nil] specified traits
       # @param select [Method] select method object used with `nested_attribute` and `trait`
-      def initialize(object, params: EMPTY_HASH, within: WITHIN_DEFAULT, with_traits: nil, select: nil)
+      def initialize(object, params: EMPTY_HASH, within: WITHIN_DEFAULT, select: nil)
         @object = object
         @params = params
         @within = within
-        @with_traits = with_traits
         # select override to share the same method with `trait` and `nested_attribute`
         # Trait and NestedAttribute generates anonymous class so it checks if it's anonymous class to prevent accidental overriding
         self.class.define_method(:select, &select) if select && self.class.name.nil?
@@ -115,19 +113,6 @@ module Alba
       alias to_h serializable_hash
 
       private
-
-      def hash_from_traits(obj)
-        return {} if @with_traits.nil?
-
-        Array(@with_traits).each_with_object({}) do |trait, hash|
-          body = @_traits.fetch(trait) { raise Alba::Error, "Trait not found: #{trait}" }
-          resource_class = Class.new(self.class)
-          resource_class.instance_variable_set(:@_attributes, {})
-          resource_class.class_eval(&body)
-          resource_class.transform_keys(@_transform_type) unless @_transform_type == :none
-          hash.merge!(resource_class.new(obj, params: params, within: @within, select: method(:select)).serializable_hash)
-        end
-      end
 
       def deprecated_serializable_hash
         Alba.collection?(@object) ? serializable_hash_for_collection : converter.call(@object)
@@ -235,7 +220,7 @@ module Alba
         rescue StandardError => e
           handle_error(e, obj, key, attribute, hash)
         end
-        @with_traits.nil? ? hash : hash.merge!(hash_from_traits(obj))
+        hash
       end
 
       # This is default behavior for getting attributes for serialization
@@ -353,6 +338,31 @@ module Alba
     # Class methods
     module ClassMethods
       attr_reader(*INTERNAL_VARIABLES.keys)
+
+      # @param with_traits [Symbol, Array<Symbol>, nil] traits to apply, in the given order
+      # @raise [Alba::Error] when a trait is not defined on this resource
+      # @see InstanceMethods#initialize
+      def new(object, params: EMPTY_HASH, within: WITHIN_DEFAULT, with_traits: nil, select: nil)
+        if with_traits.nil?
+          super(object, params: params, within: within, select: select)
+        else
+          class_with_traits(Array(with_traits)).new(object, params: params, within: within, select: select)
+        end
+      end
+
+      # A subclass with the given traits applied, built once per trait combination.
+      def class_with_traits(traits)
+        @_classes_with_traits ||= {}
+        @_classes_with_traits[traits] || begin
+          resource_class = Class.new(self)
+          resource_class.define_singleton_method(:name) { superclass.name }
+          traits.each do |trait|
+            resource_class.class_eval(&_traits.fetch(trait) { raise Alba::Error, "Trait not found: #{trait}" })
+          end
+          @_classes_with_traits[traits.dup.freeze] = resource_class
+        end
+      end
+      private :class_with_traits
 
       # This `method_added` is used for defining "resource methods"
       def method_added(method_name) # rubocop:disable Metrics/MethodLength
@@ -576,6 +586,8 @@ module Alba
       # @see #transform_keys
       def transform_keys!(type)
         dup.class_eval do
+          # Class#dup copies the memo, whose classes were built with the old transform type
+          @_classes_with_traits = nil
           transform_keys(type, root: @_transforming_root_key, cascade: @_key_transformation_cascade)
 
           if @_key_transformation_cascade

--- a/sig/alba/resource.rbs
+++ b/sig/alba/resource.rbs
@@ -22,7 +22,6 @@ module Alba
         untyped object,
         ?params: generic_hash,
         ?within: within,
-        ?with_traits: Symbol | Array[Symbol] | nil,
         ?select: Method?
       ) -> void
 
@@ -127,6 +126,14 @@ module Alba
 
       # Traits
       def trait: (Symbol name) { () -> void } -> void
+      def new: (
+        untyped object,
+        ?params: generic_hash,
+        ?within: within,
+        ?with_traits: Symbol | Array[Symbol] | nil,
+        ?select: Method?
+      ) -> untyped
+      def class_with_traits: (Array[Symbol] traits) -> untyped
 
       # Type checking
       def typed_attribute: (Symbol | String name, Symbol | Class type, **untyped opts) -> void

--- a/sig/alba/resource.rbs
+++ b/sig/alba/resource.rbs
@@ -12,19 +12,17 @@ module Alba
       @object: untyped
       @params: generic_hash
       @within: untyped
-      @with_traits: Symbol | Array[Symbol] | nil
 
       attr_reader object: untyped
       attr_reader params: generic_hash
 
-      def initialize: (untyped, ?params: generic_hash, ?within: untyped, ?with_traits: Symbol | Array[Symbol] | nil, ?select: Method?) -> void
+      def initialize: (untyped, ?params: generic_hash, ?within: untyped, ?select: Method?) -> void
       def serialize: (?root_key: root_key_type, ?meta: generic_hash) -> String
       def to_json: (?generic_hash, ?root_key: root_key_type, ?meta: generic_hash) -> String
       def as_json: (?generic_hash, ?root_key: root_key_type, ?meta: generic_hash) -> untyped
       def serializable_hash: () -> untyped
       alias to_h serializable_hash
 
-      def hash_from_traits: (untyped) -> untyped
       def deprecated_serializable_hash: () -> untyped
       def serialize_with: (untyped) -> String
       def hash_with_metadata: (untyped, generic_hash) -> untyped
@@ -94,6 +92,7 @@ module Alba
       @_resource_methods: Array[Symbol]
       @_select_arity: Integer?
       @_traits: Hash[Symbol, Proc]
+      @_classes_with_traits: Hash[Array[Symbol], untyped]?
 
       def alias_method: (Symbol, Symbol) -> Symbol
       def private: (*Symbol) -> untyped
@@ -104,7 +103,10 @@ module Alba
       def module_eval: [A] () { () [self: untyped] -> A } -> A
       def name: () -> untyped
       def dup: () -> untyped
-      def new: (*untyped, **untyped) -> untyped
+      def new: (untyped, ?with_traits: Symbol | Array[Symbol] | nil, **untyped) -> untyped
+      private def class_with_traits: (untyped) -> untyped
+      private def build_class_with_traits: (untyped) -> untyped
+      def itself: () -> Class
       def _resource_methods: () -> Array[Symbol]
 
       def method_added: (Symbol) -> untyped

--- a/sig/alba/resource.rbs
+++ b/sig/alba/resource.rbs
@@ -133,7 +133,7 @@ module Alba
         ?with_traits: Symbol | Array[Symbol] | nil,
         ?select: Method?
       ) -> untyped
-      def class_with_traits: (Array[Symbol] traits) -> untyped
+      private def class_with_traits: (Array[Symbol] traits) -> untyped
 
       # Type checking
       def typed_attribute: (Symbol | String name, Symbol | Class type, **untyped opts) -> void

--- a/test/usecases/key_transform_test.rb
+++ b/test/usecases/key_transform_test.rb
@@ -196,6 +196,28 @@ class KeyTransformTest < Minitest::Test
     )
   end
 
+  class UserWithTransformingTraitResource
+    include Alba::Resource
+
+    attributes :id, :first_name
+
+    trait :camelized do
+      transform_keys :camel
+      attributes :last_name
+    end
+  end
+
+  def test_transform_key_inside_trait_applies_to_the_whole_output
+    assert_equal(
+      '{"Id":1,"FirstName":"Masafumi","LastName":"Okura"}',
+      UserWithTransformingTraitResource.new(@user, with_traits: :camelized).serialize
+    )
+    assert_equal(
+      '{"id":1,"first_name":"Masafumi"}',
+      UserWithTransformingTraitResource.new(@user).serialize
+    )
+  end
+
   def test_transform_key_bang_with_trait
     assert_equal(
       '{"Id":1,"FirstName":"Masafumi","LastName":"Okura"}',

--- a/test/usecases/trait_test.rb
+++ b/test/usecases/trait_test.rb
@@ -287,18 +287,58 @@ class TraitTest < Minitest::Test
     )
   end
 
+  class UserResourceWithConflictingTraits
+    include Alba::Resource
+
+    attributes :id
+
+    trait :upcased_name do
+      attribute :name do |user|
+        user.name.upcase
+      end
+    end
+
+    trait :downcased_name do
+      attribute :name do |user|
+        user.name.downcase
+      end
+    end
+  end
+
   def test_traits_applied_in_a_different_order_do_not_share_their_attributes
     assert_equal(
-      '{"id":1,"name":"MASAFUMI OKURA","greeting":"Hello, Masafumi OKURA!"}',
-      UserResourceWithOverride.new(@user, with_traits: %i[with_greeting with_uppercased_name]).serialize
+      '{"id":1,"name":"masafumi okura"}',
+      UserResourceWithConflictingTraits.new(@user, with_traits: %i[upcased_name downcased_name]).serialize
     )
     assert_equal(
-      '{"id":1,"name":"MASAFUMI OKURA","greeting":"Hello, Masafumi OKURA!"}',
-      UserResourceWithOverride.new(@user, with_traits: %i[with_uppercased_name with_greeting]).serialize
+      '{"id":1,"name":"MASAFUMI OKURA"}',
+      UserResourceWithConflictingTraits.new(@user, with_traits: %i[downcased_name upcased_name]).serialize
     )
     assert_equal(
-      '{"id":1,"name":"Masafumi OKURA"}',
-      UserResourceWithOverride.new(@user).serialize
+      '{"id":1}',
+      UserResourceWithConflictingTraits.new(@user).serialize
     )
+  end
+
+  def test_redefining_a_trait_rebuilds_the_memoized_trait_class
+    resource_class = Class.new do
+      include Alba::Resource
+
+      attributes :id
+
+      trait :extra do
+        attributes :name
+      end
+    end
+
+    assert_equal '{"id":1,"name":"Masafumi OKURA"}', resource_class.new(@user, with_traits: :extra).serialize
+
+    resource_class.class_eval do
+      trait :extra do
+        attributes :email
+      end
+    end
+
+    assert_equal '{"id":1,"email":"masafumi@example.com"}', resource_class.new(@user, with_traits: :extra).serialize
   end
 end

--- a/test/usecases/trait_test.rb
+++ b/test/usecases/trait_test.rb
@@ -266,6 +266,27 @@ class TraitTest < Minitest::Test
     assert_equal 1, evaluations
   end
 
+  class UserResourceWithSelect
+    include Alba::Resource
+
+    attributes :id
+
+    trait :name_and_email do
+      attributes :name, :email
+    end
+
+    def select(_key, value)
+      !value.to_s.include?('@')
+    end
+  end
+
+  def test_select_defined_on_the_resource_filters_trait_attributes
+    assert_equal(
+      '{"id":1,"name":"Masafumi OKURA"}',
+      UserResourceWithSelect.new(@user, with_traits: :name_and_email).serialize
+    )
+  end
+
   def test_traits_applied_in_a_different_order_do_not_share_their_attributes
     assert_equal(
       '{"id":1,"name":"MASAFUMI OKURA","greeting":"Hello, Masafumi OKURA!"}',

--- a/test/usecases/trait_test.rb
+++ b/test/usecases/trait_test.rb
@@ -193,4 +193,91 @@ class TraitTest < Minitest::Test
       UserResourceWithOverride.new(@user, with_traits: [:with_greeting]).serialize
     )
   end
+
+  class UserWithMethodInTraitResource < UserResource
+    trait :with_shouted_name do
+      attributes :shouted_name
+
+      def shouted_name(user)
+        user.name.upcase
+      end
+    end
+  end
+
+  def test_method_defined_in_trait_is_available_during_serialization
+    assert_equal(
+      '{"id":1,"shouted_name":"MASAFUMI OKURA"}',
+      UserWithMethodInTraitResource.new(@user, with_traits: :with_shouted_name).serialize
+    )
+  end
+
+  class UserWithRootKeyResource < UserResource
+    root_key!
+  end
+
+  def test_trait_with_inferred_root_key
+    original_inflector = Alba.inflector
+    Alba.inflector = :default
+    assert_equal(
+      '{"user_with_root_key":{"id":1,"name":"Masafumi OKURA","email":"masafumi@example.com"}}',
+      UserWithRootKeyResource.new(@user, with_traits: :name_and_email).serialize
+    )
+  ensure
+    Alba.inflector = original_inflector
+  end
+
+  def test_trait_is_evaluated_once_however_many_objects_are_serialized
+    evaluations = 0
+    resource_class = Class.new do
+      include Alba::Resource
+
+      attributes :id
+
+      trait :counted do
+        evaluations += 1
+        attributes :name
+      end
+    end
+    users = [@user, User.new(2, 'Foo', 'foo@example.com'), User.new(3, 'Bar', 'bar@example.com')]
+
+    resource_class.new(users, with_traits: [:counted]).serialize
+
+    assert_equal 1, evaluations
+  end
+
+  def test_trait_is_not_reevaluated_when_the_caller_mutates_the_traits_array
+    evaluations = 0
+    resource_class = Class.new do
+      include Alba::Resource
+
+      attributes :id
+
+      trait :counted do
+        evaluations += 1
+        attributes :name
+      end
+    end
+    traits = [:counted]
+
+    resource_class.new(@user, with_traits: traits).serialize
+    traits << :counted
+    resource_class.new(@user, with_traits: [:counted]).serialize
+
+    assert_equal 1, evaluations
+  end
+
+  def test_traits_applied_in_a_different_order_do_not_share_their_attributes
+    assert_equal(
+      '{"id":1,"name":"MASAFUMI OKURA","greeting":"Hello, Masafumi OKURA!"}',
+      UserResourceWithOverride.new(@user, with_traits: %i[with_greeting with_uppercased_name]).serialize
+    )
+    assert_equal(
+      '{"id":1,"name":"MASAFUMI OKURA","greeting":"Hello, Masafumi OKURA!"}',
+      UserResourceWithOverride.new(@user, with_traits: %i[with_uppercased_name with_greeting]).serialize
+    )
+    assert_equal(
+      '{"id":1,"name":"Masafumi OKURA"}',
+      UserResourceWithOverride.new(@user).serialize
+    )
+  end
 end

--- a/test/usecases/trait_test.rb
+++ b/test/usecases/trait_test.rb
@@ -266,6 +266,48 @@ class TraitTest < Minitest::Test
     assert_equal 1, evaluations
   end
 
+  class UserResourceWithSelect
+    include Alba::Resource
+
+    attributes :id
+
+    trait :name_and_email do
+      attributes :name, :email
+    end
+
+    def select(_key, value)
+      !value.to_s.include?('@')
+    end
+  end
+
+  def test_select_defined_on_the_resource_filters_trait_attributes
+    assert_equal(
+      '{"id":1,"name":"Masafumi OKURA"}',
+      UserResourceWithSelect.new(@user, with_traits: :name_and_email).serialize
+    )
+  end
+
+  def test_select_passed_to_new_applies_per_call_despite_the_memoized_trait_class
+    resource_class = Class.new do
+      include Alba::Resource
+
+      attributes :id
+
+      trait :with_name do
+        attributes :name
+      end
+    end
+    drop_strings = ->(_key, value) { !value.is_a?(String) }
+    keep_all = ->(_key, _value) { true }
+
+    assert_equal '{"id":1}', resource_class.new(@user, with_traits: :with_name, select: drop_strings).serialize
+    assert_equal(
+      '{"id":1,"name":"Masafumi OKURA"}',
+      resource_class.new(@user, with_traits: :with_name, select: keep_all).serialize
+    )
+    assert_equal '{"id":1}', resource_class.new(@user, with_traits: :with_name, select: drop_strings).serialize
+  end
+
   def test_traits_applied_in_a_different_order_do_not_share_their_attributes
     assert_equal(
       '{"id":1,"name":"MASAFUMI OKURA","greeting":"Hello, Masafumi OKURA!"}',


### PR DESCRIPTION
## Problem

A trait was resolved while serializing each object: `hash_from_traits` built a fresh subclass, evaluated the trait body on it, instantiated a second resource around the object and merged the resulting hash. A resource serializing a collection repeated all of that for every object, so an attribute declared in a trait cost far more than the same attribute declared inline, and the cost grew with the number of objects.

## Solution

Which subclass a set of traits produces does not depend on the object being serialized, so it is now built once per trait combination, memoized on the resource class, and `.new` returns an instance of it whenever `with_traits:` is given. Serialization then runs entirely on that subclass, so everything a trait body declares works the way it does on any resource class, through plain inheritance: methods defined in a trait become resource methods, and `transform_keys`, `root_key` or `select` simply take effect.

Traits still compose in the same order as before: each trait is evaluated on top of what came before it, so a later trait overrides an earlier one, and any trait overrides declarations from the resource itself.

Details worth calling out:

- The memoized subclass is anonymous, so it reports its superclass's `name` for root key inference.
- `transform_keys!` clears the memo on the class it dups, because `Class#dup` copies instance variables and the memoized classes were built with the old transform type.
- The memo key is a frozen copy of the trait list, so a caller mutating the array it passed does not corrupt the cache.

## Behavioural changes

- A trait body is evaluated once per trait combination instead of once per serialized object, so side effects or runtime conditionals inside a trait body no longer run on every serialization.
- `transform_keys` inside a trait now applies to the whole output of the resource serialized with that trait, not only to the keys the trait defines (previously it was honored only when the resource itself had no transform type, and only for the trait's own keys).

## Benchmark

`benchmark/traits.rb` (added in this PR) serializes 100 posts and compares the same JSON produced with attributes declared inline vs declared in a trait, for a plain attribute and for an association with 20 comments per post. "Before" is `main` at 3.11.0, "after" is this branch merged with it; both were measured with this same script on Ruby 4.0.5 (arm64, YJIT). Inline is the baseline, is what the same attributes cost when declared directly on the resource, and is unaffected by this PR — the two runs each carry their own inline figure, and a trait is meaningful only next to the inline number from the same run.

Speed (higher is better):

| | before: inline | before: trait | after: inline | after: trait |
|---|---|---|---|---|
| plain attribute | 15 035 i/s | 1109 i/s (13.6x slower) | 18 214 i/s | 15 002 i/s (1.21x slower) |
| association | 944 i/s | 456 i/s (2.07x slower) | 852 i/s | 845 i/s (1.01x slower) |

Allocated memory per serialization (lower is better):

| | before: inline | before: trait | after: inline | after: trait |
|---|---|---|---|---|
| plain attribute | 33 568 B | 393 568 B (11.7x more) | 33 568 B | 33 768 B (+200 B) |
| association | 817 961 B | 1 248 361 B (1.53x more) | 833 961 B | 834 161 B (+200 B) |

Measured end to end: a trait carrying a plain attribute goes from 1109 i/s to 15 002 i/s (13.5x) and from 394 kB to 34 kB per serialization (11.7x less), and a trait carrying an association from 456 i/s to 845 i/s (1.85x) and from 1.25 MB to 834 kB.

## Tests

New tests cover: a trait body being evaluated once, however many objects are serialized, methods defined inside a trait working as resource methods, `transform_keys` inside a trait, root key inference combined with traits, trait order isolation in the memo, and the memo surviving the caller mutating the traits array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Changed

- Traits are now applied consistently at the resource-class level, improving serialization of collections.
- Trait logic is evaluated once per trait combination, reducing repeated work.
- `transform_keys` declared within a trait applies to the complete serialized output.
- Trait methods and inferred root keys continue to work correctly, including when traits are combined in different orders.

## Tests

- Added coverage for trait transforms, memoization, trait ordering, and filtering behavior.

## Documentation

- Updated the changelog with the revised trait behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
