### PR TITLE
[Fix] Call #nil? on attribute values only when a nil handler is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `Alba.non_collection_types` for declaring Enumerable classes that should not be treated as collections [#532](https://github.com/okuramasafumi/alba/pull/532)
 
+### Changed
+
+- Skip calling `#nil?` on attribute values when no nil handler (`on_nil`) is set, so lazy-loading proxies such as batch-loader keep their batching
+
 ### Fixed
 
 - Trait redefining base-level attribute causes wrong result with multiple traits [#498](https://github.com/okuramasafumi/alba/issues/498) and [#502](https://github.com/okuramasafumi/alba/pull/502)

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -301,7 +301,7 @@ module Alba
                 else raise ::Alba::Error, "Unsupported type of attribute: #{attribute.class}"
                   # :nocov:
                 end
-        value.nil? && nil_handler ? instance_exec(obj, key, attribute, &nil_handler) : value
+        nil_handler && value.nil? ? instance_exec(obj, key, attribute, &nil_handler) : value
       end
 
       def fetch_attribute_from_object_and_resource(obj, attribute)

--- a/test/usecases/nil_handler_test.rb
+++ b/test/usecases/nil_handler_test.rb
@@ -152,4 +152,51 @@ class NilHandlerTest < Minitest::Test
       UserResource2.new(@user3).serialize
     )
   end
+
+  # Lazy-loading proxies (e.g. batch-loader) implement `nil?` with a side effect
+  # that forces the load, so it must be called only when a nil handler is set.
+  class ValueTrackingNilCheck
+    attr_reader :nil_checked
+
+    def initialize
+      @nil_checked = false
+    end
+
+    def nil?
+      @nil_checked = true
+      super
+    end
+  end
+
+  class Item
+    attr_reader :value
+
+    def initialize(value)
+      @value = value
+    end
+  end
+
+  class ItemResource
+    include Alba::Resource
+
+    attributes :value
+  end
+
+  class ItemResourceWithNilHandler < ItemResource
+    on_nil { '' }
+  end
+
+  def test_without_nil_handler_it_does_not_call_nil_predicate_on_attribute_values
+    value = ValueTrackingNilCheck.new
+    ItemResource.new(Item.new(value)).serializable_hash
+
+    refute value.nil_checked
+  end
+
+  def test_with_nil_handler_it_calls_nil_predicate_on_attribute_values
+    value = ValueTrackingNilCheck.new
+    ItemResourceWithNilHandler.new(Item.new(value)).serializable_hash
+
+    assert value.nil_checked
+  end
 end


### PR DESCRIPTION
## What

A one-line operand swap in `Alba::Resource::InstanceMethods#fetch_attribute`:

```ruby
# Before
value.nil? && nil_handler ? instance_exec(obj, key, attribute, &nil_handler) : value
# After
nil_handler && value.nil? ? instance_exec(obj, key, attribute, &nil_handler) : value
```

`#nil?` is now called on attribute values only when the resource declares a nil handler (`on_nil`).

## Why

`fetch_attribute` called `value.nil?` on every attribute value even when no `on_nil` handler was set (the common case), and the result was discarded because `nil_handler` was falsy.

For plain objects this is just one redundant method call per attribute. For lazy-loading proxies such as [batch-loader](https://github.com/exAspArk/batch-loader), it is worse: they implement `#nil?` via `method_missing` with a side effect that forces the load immediately. When serializing a collection, each record's proxy is forced one by one while the hash is being built, which turns "collect all proxies, then load them in one batch" into N+1 queries. We hit this in production after porting collection serializers from ActiveModelSerializers (which only touches values at encoding time) to Alba.

As far as I can tell, this is the only place where Alba calls a method on every attribute value unconditionally (`TypedAttribute#display_value_for` only runs for typed attributes on the `TypeError` path, and `select`/conditional procs are opt-in). So with this change, lazy values pass through hash building untouched end-to-end; the only remaining consideration for lazy-proxy users is resolution at encoding time, which is backend-dependent and outside `fetch_attribute`'s scope (see Behavior notes below).

## Behavior

No documented behavior changes — the entire existing test suite passes unchanged.

- With `on_nil` set: `#nil?` is evaluated exactly as before.
- Without `on_nil`: `#nil?` is no longer called. `#nil?` on a plain Ruby object is a side-effect-free predicate, and its result was discarded here anyway, so there is no observable difference — it just saves one method call per attribute.

The only way to observe a difference is an object whose `#nil?` itself has side effects — i.e. lazy proxies, which is what this PR is about. Two notes for such users:

- Proxies now reach the serialized hash unresolved. Whether encoding triggers their lazy load depends on the backend: backends that call serialization methods on values (like the default JSON one) resolve them at encode time in a single batch — the desired behavior — while Oj-based backends dispatch on the value's actual class, so proxies should be resolved before encoding (e.g. with a custom `Alba.encoder` that walks the hash).
- With `on_error` declared but no `on_nil`, a proxy whose load fails used to raise while fetching the attribute (where `on_error` could handle it), because `#nil?` forced the load there. The error now surfaces at encoding time instead.

Both notes describe objects relying on side effects of an internal evaluation order, not documented Alba behavior, so I kept the change as a plain swap. Happy to target a minor release rather than a patch if you prefer.

## Tests

Added two tests in `test/usecases/nil_handler_test.rb` using a value object that records whether `#nil?` was called:

- without `on_nil` → `#nil?` is not called (fails without this change)
- with `on_nil` → `#nil?` is still called (guards handler semantics)

`rake test` (283 runs), `rubocop`, and `rake typecheck` (RBS + Steep) all pass. No `sig/` changes needed — no signature change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Serialization no longer calls an attribute value’s `nil?` check when no nil-handling option is configured.
  * This improves compatibility with lazy-loading and proxy-backed values.
  * Nil checks continue to run when custom nil handling is configured.

* **Documentation**
  * Updated the unreleased changelog to document this behavior change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->