### PR TITLE
[Feat] Add default superclass configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,20 @@ else
 end
 ```
 
+#### Default superclass configuration
+
+You can set the default superclass for resource classes created for Nested Attributes and Traits.
+
+```ruby
+Alba.default_superclass = MyBaseSerializer
+```
+
+Note that in some environments like Rails applications, the class object is not loaded in the initializer phase. You can also set `String`.
+
+```ruby
+Alba.default_superclass = 'MyBaseSerializer'
+```
+
 ### Naming
 
 Alba tries to infer resource name from class name like the following.

--- a/lib/alba.rb
+++ b/lib/alba.rb
@@ -19,6 +19,13 @@ module Alba
     # @return [Array<Class>] classes that include Enumerable but should not be treated as collections
     attr_reader :non_collection_types
 
+    # Set the default superclass for resource classes created with {.resource_class}
+    #
+    # @param value [Class, String, Symbol] the default superclass
+    # @example
+    #   Alba.default_superclass = '::MyApp::BaseResource'
+    attr_writer :default_superclass
+
     # Set the backend, which actually serializes object into JSON
     #
     # @param backend [#to_sym, nil] the name of the backend
@@ -131,7 +138,7 @@ module Alba
     # @param block [Block] resource body
     # @return [Class<Alba::Resource>] resource class
     def resource_class(&block)
-      klass = Class.new
+      klass = Class.new(resolved_default_superclass)
       klass.include(Alba::Resource)
       klass.class_eval(&block) if block
       klass
@@ -224,6 +231,7 @@ module Alba
       @_on_nil = nil
       @types = {}
       @non_collection_types = [Struct, Range, Hash]
+      @default_superclass = ::Object
       reset_transform_keys
       register_default_types
     end
@@ -340,6 +348,10 @@ module Alba
 
     def reset_transform_keys
       @_transformed_keys = Hash.new { |h, k| h[k] = {} }
+    end
+
+    def resolved_default_superclass
+      @default_superclass.is_a?(Class) ? @default_superclass : Object.const_get(@default_superclass.to_s)
     end
 
     def register_default_types # rubocop:disable Metrics/AbcSize

--- a/sig/alba.rbs
+++ b/sig/alba.rbs
@@ -36,6 +36,8 @@ module Alba
   def self.inflector: () -> inflector_type
   def self.inflector=: (Symbol | inflector_type) -> void
 
+  def self.default_superclass=: (Class | String | Symbol) -> void
+
   # Serialization methods
   def self.serialize: (untyped object, ?with: :inference | Proc | resource_class, ?root_key: key_type) ?{ () -> void } -> String
   def self.hashify: (untyped object, ?with: :inference | Proc | resource_class, ?root_key: key_type) ?{ () -> void } -> generic_hash

--- a/test/alba_test.rb
+++ b/test/alba_test.rb
@@ -34,6 +34,8 @@ class AlbaTest < Minitest::Test
     end
   end
 
+  CustomResourceSuperclass = Class.new
+
   def setup
     Alba.backend = nil
 
@@ -46,6 +48,16 @@ class AlbaTest < Minitest::Test
 
   def teardown
     Alba.backend = nil
+  end
+
+  def test_resource_class_uses_configured_default_superclass
+    [CustomResourceSuperclass, 'AlbaTest::CustomResourceSuperclass', :'AlbaTest::CustomResourceSuperclass'].each do |superclass|
+      Alba.default_superclass = superclass
+
+      assert_equal CustomResourceSuperclass, Alba.resource_class.superclass
+    end
+  ensure
+    Alba.reset!
   end
 
   def test_it_serializes_object_with_block


### PR DESCRIPTION
Related: #503 

I concluded that providing configuration of default superclass for newly created resources (NestedAttributes and Traits) would benefit with simpler code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `default_superclass` configuration to control the superclass used when generating resource classes.
  * You can set it using a class, a constant name, or a symbol.
  * Resource classes now inherit from the configured default superclass.
* **Documentation**
  * Documented the new configuration option, including usage examples and a Rails initializer caveat.
* **Tests**
  * Added coverage to verify superclass selection across the supported configuration formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->