### PR TITLE
Memoize nested attribute classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The class backing a nested attribute is now built once instead of once per serialized object, so a nested attribute body is evaluated once however many objects are serialized
+
 ## 3.11.0 2026-07-25
 
 ### Added

--- a/benchmark/nested_attributes.rb
+++ b/benchmark/nested_attributes.rb
@@ -1,0 +1,86 @@
+# Benchmark script to measure what a nested attribute costs.
+#
+# Each pair of resources below serializes the same attributes, once declared directly on the resource
+# and once declared inside a nested attribute, so whatever separates the two is what nesting costs.
+
+require_relative 'prep'
+
+require 'alba'
+
+# --- Attributes on the resource ---
+
+class FlatCommentResource
+  include Alba::Resource
+  attributes :id, :body
+end
+
+class FlatPostResource
+  include Alba::Resource
+  attributes :id, :body
+end
+
+class FlatPostWithCommentsResource
+  include Alba::Resource
+  attributes :id, :body
+  many :comments, resource: FlatCommentResource
+end
+
+# --- The same attributes, in a nested attribute ---
+
+class NestedCommentResource
+  include Alba::Resource
+  attributes :id, :body
+end
+
+class NestedPostResource
+  include Alba::Resource
+  attributes :id
+
+  nested_attribute :details do
+    attributes :body
+  end
+end
+
+class NestedPostWithCommentsResource
+  include Alba::Resource
+  attributes :id
+
+  nested_attribute :details do
+    attributes :body
+    many :comments, resource: NestedCommentResource
+  end
+end
+
+# --- Test data creation ---
+
+100.times do |i|
+  post = Post.create!(body: "post#{i}")
+  user1 = User.create!(name: "John#{i}")
+  user2 = User.create!(name: "Jane#{i}")
+  10.times do |n|
+    post.comments.create!(commenter: user1, body: "Comment1_#{i}_#{n}")
+    post.comments.create!(commenter: user2, body: "Comment2_#{i}_#{n}")
+  end
+end
+
+posts = Post.all.includes(:comments, :commenters)
+
+flat_attribute = proc { FlatPostResource.new(posts).serialize }
+nested_attribute = proc { NestedPostResource.new(posts).serialize }
+flat_association = proc { FlatPostWithCommentsResource.new(posts).serialize }
+nested_association = proc { NestedPostWithCommentsResource.new(posts).serialize }
+
+benchmark_body = lambda do |x|
+  x.report(:attribute_flat, &flat_attribute)
+  x.report(:attribute_nested, &nested_attribute)
+  x.report(:association_flat, &flat_association)
+  x.report(:association_nested, &nested_association)
+
+  x.compare!
+end
+
+require 'benchmark/ips'
+Benchmark.ips(&benchmark_body)
+
+require 'benchmark/memory'
+Benchmark.memory(&benchmark_body)

--- a/benchmark/nested_attributes.rb
+++ b/benchmark/nested_attributes.rb
@@ -1,36 +1,32 @@
 # Benchmark script to measure what a nested attribute costs.
 #
-# Each pair of resources below serializes the same attributes, once declared directly on the resource
-# and once declared inside a nested attribute, so whatever separates the two is what nesting costs.
+# Each pair of resources below serializes exactly the same JSON, once with the nested hash built by hand in a plain
+# attribute and once with `nested_attribute`, so whatever separates the two is what the nested attribute costs.
 
 require_relative 'prep'
 
 require 'alba'
 
-# --- Attributes on the resource ---
-
-class FlatCommentResource
+class CommentResource
   include Alba::Resource
   attributes :id, :body
 end
 
-class FlatPostResource
+# --- The nested hash built by hand ---
+
+class ManualPostResource
   include Alba::Resource
-  attributes :id, :body
+  attributes :id
+  attribute(:details) { |post| {body: post.body} }
 end
 
-class FlatPostWithCommentsResource
+class ManualPostWithCommentsResource
   include Alba::Resource
-  attributes :id, :body
-  many :comments, resource: FlatCommentResource
+  attributes :id
+  attribute(:details) { |post| {body: post.body, comments: CommentResource.new(post.comments).serializable_hash} }
 end
 
-# --- The same attributes, in a nested attribute ---
-
-class NestedCommentResource
-  include Alba::Resource
-  attributes :id, :body
-end
+# --- The same JSON, through a nested attribute ---
 
 class NestedPostResource
   include Alba::Resource
@@ -47,7 +43,7 @@ class NestedPostWithCommentsResource
 
   nested_attribute :details do
     attributes :body
-    many :comments, resource: NestedCommentResource
+    many :comments, resource: CommentResource
   end
 end
 
@@ -65,15 +61,18 @@ end
 
 posts = Post.all.includes(:comments, :commenters)
 
-flat_attribute = proc { FlatPostResource.new(posts).serialize }
+manual_attribute = proc { ManualPostResource.new(posts).serialize }
 nested_attribute = proc { NestedPostResource.new(posts).serialize }
-flat_association = proc { FlatPostWithCommentsResource.new(posts).serialize }
+manual_association = proc { ManualPostWithCommentsResource.new(posts).serialize }
 nested_association = proc { NestedPostWithCommentsResource.new(posts).serialize }
 
+raise 'manual and nested must serialize the same JSON' unless manual_attribute.call == nested_attribute.call
+raise 'manual and nested must serialize the same JSON' unless manual_association.call == nested_association.call
+
 benchmark_body = lambda do |x|
-  x.report(:attribute_flat, &flat_attribute)
+  x.report(:attribute_manual, &manual_attribute)
   x.report(:attribute_nested, &nested_attribute)
-  x.report(:association_flat, &flat_association)
+  x.report(:association_manual, &manual_association)
   x.report(:association_nested, &nested_association)
 
   x.compare!

--- a/lib/alba/nested_attribute.rb
+++ b/lib/alba/nested_attribute.rb
@@ -4,9 +4,6 @@ module Alba
   # Representing nested attribute
   # @api private
   class NestedAttribute
-    # Setter for key_transformation, used when it's changed after class definition
-    attr_writer :key_transformation
-
     # @param klass [Class<Alba::Resource>] the parent for this nested attribute
     # @param key_transformation [Symbol] determines how to transform keys
     # @param block [Proc] class body
@@ -14,6 +11,16 @@ module Alba
       @klass = klass
       @key_transformation = key_transformation
       @block = block
+      @resource_class = nil
+    end
+
+    # Setter for key_transformation, used when it's changed after class definition
+    #
+    # @param key_transformation [Symbol] determines how to transform keys
+    # @return [void]
+    def key_transformation=(key_transformation)
+      @resource_class = nil
+      @key_transformation = key_transformation
     end
 
     # @param object [Object] the object being serialized
@@ -21,11 +28,21 @@ module Alba
     # @param within [Object, nil, false, true] determines what associations to be serialized. If not set, it serializes all associations.
     # @return [Hash] hash serialized from running the class body in the object
     def value(object:, params:, within:)
+      resource_class.new(object, params: params, within: within).serializable_hash
+    end
+
+    private
+
+    def resource_class
+      @resource_class ||= build_resource_class
+    end
+
+    def build_resource_class
       resource_class = Class.new(@klass)
       resource_class.instance_variable_set(:@_attributes, {}) # reset
       resource_class.transform_keys(@key_transformation)
       resource_class.class_eval(&@block)
-      resource_class.new(object, params: params, within: within).serializable_hash
+      resource_class
     end
   end
 end

--- a/sig/alba/nested_attribute.rbs
+++ b/sig/alba/nested_attribute.rbs
@@ -1,21 +1,26 @@
 module Alba
   # Representing nested attribute
   class NestedAttribute
-    attr_writer key_transformation: Symbol | String
-
     @key_transformation: Symbol | String
     @block: untyped
     @klass: untyped
+    @resource_class: untyped
 
     def initialize: (
       klass: untyped,
       ?key_transformation: Alba::transform_type
     ) { () -> void } -> void
 
+    def key_transformation=: (Symbol | String) -> (Symbol | String)
+
     def value: (
       object: untyped,
       params: generic_hash,
       within: within
     ) -> generic_hash
+
+    def resource_class: () -> untyped
+
+    def build_resource_class: () -> untyped
   end
 end

--- a/sig/alba/nested_attribute.rbs
+++ b/sig/alba/nested_attribute.rbs
@@ -19,8 +19,8 @@ module Alba
       within: within
     ) -> generic_hash
 
-    def resource_class: () -> untyped
+    private def resource_class: () -> untyped
 
-    def build_resource_class: () -> untyped
+    private def build_resource_class: () -> untyped
   end
 end

--- a/test/usecases/nested_attribute_test.rb
+++ b/test/usecases/nested_attribute_test.rb
@@ -201,4 +201,37 @@ class NestedAttributeTest < Minitest::Test
       Bar6Resource.new(Bar.new('foo')).serialize
     )
   end
+
+  def test_nested_attribute_block_is_evaluated_once_however_many_objects_are_serialized
+    evaluations = 0
+    resource_class = Class.new do
+      include Alba::Resource
+
+      nested_attribute :na do
+        evaluations += 1
+        attributes :some_value
+      end
+    end
+    bars = [Bar.new('foo'), Bar.new('bar'), Bar.new('baz')]
+
+    assert_equal(
+      '[{"na":{"some_value":"foo"}},{"na":{"some_value":"bar"}},{"na":{"some_value":"baz"}}]',
+      resource_class.new(bars).serialize
+    )
+    assert_equal 1, evaluations
+  end
+
+  def test_nested_attribute_block_is_reevaluated_when_key_transformation_changes
+    resource_class = Class.new do
+      include Alba::Resource
+
+      nested_attribute :na do
+        attributes :some_value
+      end
+    end
+    bar = Bar.new('foo')
+
+    assert_equal '{"na":{"some_value":"foo"}}', resource_class.new(bar).serialize
+    assert_equal '{"Na":{"SomeValue":"foo"}}', resource_class.transform_keys!(:camel).new(bar).serialize
+  end
 end


### PR DESCRIPTION
## Problem

`NestedAttribute#value` built a fresh subclass, reset its attributes, applied the key transformation and evaluated the block for every object it serialized. None of that depends on the object, so a nested attribute got more expensive the more objects a resource serialized.

## Solution

The class is built once and memoized on the attribute. The `key_transformation` setter, which `transform_keys!` calls after class definition, drops the memo so the next serialization picks up the new transformation.

## Behavioural change

A nested attribute body is evaluated once instead of once per serialized object, so side effects or runtime conditionals inside it no longer run for every object.

## Benchmark

`benchmark/nested_attributes.rb` (added in this PR) serializes 100 posts and compares the same JSON produced with the nested hash built by hand in a plain attribute vs produced by `nested_attribute`, for a plain attribute and for an association with 20 comments per post. The script asserts both sides serialize the same string. Both runs used it on Ruby 4.0.5 (arm64, YJIT). Manual is the baseline, is unaffected by this PR, and each run carries its own manual figure — a nested figure is only meaningful next to the manual one from the same run.

Speed (higher is better):

| | before: manual | before: nested | after: manual | after: nested |
|---|---|---|---|---|
| plain attribute | 21 835 i/s | 1071 i/s (20.4x slower) | 22 316 i/s | 13 214 i/s (1.69x slower) |
| association | 883 i/s | 416 i/s (2.13x slower) | 1178 i/s | 1031 i/s (1.14x slower) |

Allocated memory per serialization (lower is better):

| | before: manual | before: nested | after: manual | after: nested |
|---|---|---|---|---|
| plain attribute | 45 368 B | 369 368 B (8.14x more) | 45 368 B | 81 368 B (1.79x more) |
| association | 647 361 B | 1 061 761 B (1.64x more) | 647 361 B | 703 361 B (1.09x more) |

End to end: a nested attribute carrying a plain attribute goes from 1071 i/s to 13 214 i/s (12.3x) and from 369 kB to 81 kB per serialization, one carrying an association from 416 i/s to 1031 i/s (2.5x) and from 1.06 MB to 703 kB.

A nested attribute still costs 1.69x the hand-built hash: a nested resource is instantiated per object and its hash merged, so this removes the cost of building the class, not the cost of the instance.

## Tests

New tests cover the nested attribute body being evaluated once however many objects are serialized, and `transform_keys!` after a first serialization still taking effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved nested attribute serialization by caching the generated nested resource so nested attribute bodies are evaluated once and reused across serialized objects.
* **Bug Fixes**
  * Nested attribute output now updates correctly when key transformation settings change.
* **Tests**
  * Added coverage to ensure nested attribute blocks evaluate once and re-evaluate when key transformations change.
* **Documentation**
  * Updated the changelog to reflect the nested attribute serialization improvement.
* **Chores**
  * Refreshed nested-attribute benchmark coverage and updated related type signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
