### PR TITLE
[Feat] Missing keys on Hash-like objects serialize as null instead of raising NoMethodError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Missing keys on Hash-like objects (e.g. `Elasticsearch::Model::HashWrapper`) now serialize as `null` instead of raising `NoMethodError` on the resource when no resource method is defined
+
 ## 3.11.0 2026-07-25
 
 ### Added

--- a/lib/alba/resource.rb
+++ b/lib/alba/resource.rb
@@ -268,7 +268,7 @@ module Alba
       end
 
       def _fetch_attribute_from_object_first(obj, attribute)
-        return obj.fetch(attribute) if obj.is_a?(Hash)
+        return fetch_attribute_from_hash(obj, attribute) if obj.is_a?(Hash)
 
         obj.__send__(attribute)
       rescue NoMethodError, KeyError
@@ -276,7 +276,7 @@ module Alba
       end
 
       def _fetch_attribute_from_resource_first(obj, attribute)
-        return obj.fetch(attribute) if obj.is_a?(Hash)
+        return fetch_attribute_from_hash(obj, attribute) if obj.is_a?(Hash)
 
         if @_resource_methods.include?(attribute)
           __send__(attribute, obj)
@@ -285,6 +285,15 @@ module Alba
         end
       rescue KeyError
         __send__(attribute, obj)
+      end
+
+      # When the key is missing, falls back to a resource method if defined, otherwise returns nil.
+      def fetch_attribute_from_hash(obj, attribute)
+        obj.fetch(attribute)
+      rescue KeyError
+        return __send__(attribute, obj) if @_resource_methods.include?(attribute)
+
+        nil
       end
 
       def nil_handler

--- a/sig/alba/resource.rbs
+++ b/sig/alba/resource.rbs
@@ -49,6 +49,7 @@ module Alba
       def fetch_attribute_from_object_and_resource: (untyped, Symbol) -> untyped
       def _fetch_attribute_from_object_first: (untyped, Symbol) -> untyped
       def _fetch_attribute_from_resource_first: (untyped, Symbol) -> untyped
+      def fetch_attribute_from_hash: (untyped, Symbol) -> untyped
       def nil_handler: () -> untyped
       def yield_if_within: (Symbol) { (untyped) -> untyped } -> untyped
       def check_within: (Symbol) -> untyped

--- a/test/usecases/hash_serialization_test.rb
+++ b/test/usecases/hash_serialization_test.rb
@@ -54,4 +54,48 @@ class HashSerializationTest < Minitest::Test
       InstanceMethodHashResource.new(hash).serialize
     )
   end
+
+  class HashWithMissingKeysResource
+    include Alba::Resource
+
+    attributes :id, :name, :email
+  end
+
+  def test_hash_serialization_with_missing_keys
+    hash = {id: 1, name: 'test'}
+    assert_equal(
+      '{"id":1,"name":"test","email":null}',
+      HashWithMissingKeysResource.new(hash).serialize
+    )
+  end
+
+  class HashLike < Hash
+    def fetch(key, *args)
+      super(key.to_s, *args)
+    end
+  end
+
+  def test_hash_like_serialization_with_missing_keys
+    hash = HashLike['id' => 1, 'name' => 'test'] # rubocop:disable Style/StringHashKeys
+    assert_equal(
+      '{"id":1,"name":"test","email":null}',
+      HashWithMissingKeysResource.new(hash).serialize
+    )
+  end
+
+  class PreferObjectMethodHashResource
+    include Alba::Resource
+
+    prefer_object_method!
+
+    attributes :id, :name, :email
+  end
+
+  def test_hash_serialization_with_missing_keys_prefer_object_method
+    hash = {id: 1, name: 'test'}
+    assert_equal(
+      '{"id":1,"name":"test","email":null}',
+      PreferObjectMethodHashResource.new(hash).serialize
+    )
+  end
 end


### PR DESCRIPTION
Fixes #559

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed hash serialization so missing attributes are represented as `null` instead of causing an error.
  - Improved behavior for hash-like objects, including configurations that prefer object methods.

- **Documentation**
  - Added an unreleased changelog entry describing the serialization fix.

- **Tests**
  - Added coverage for missing keys across standard hashes, hash-like objects, and object-method-preferred configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->